### PR TITLE
Optimise file-writing method

### DIFF
--- a/orchestrator/src/file_formatter.rs
+++ b/orchestrator/src/file_formatter.rs
@@ -115,12 +115,12 @@ impl FileFormatter {
             OpenOptions::new().write(true).to_owned(),
             |file, file_path, _, formatted_output| {
                 let encoded_output = self.encoding.encode(&formatted_output).0;
-                file.set_len(0)
-                    .map_err(|e| format!("Failed to truncate file: {file_path}, {e}"))?;
-                file.seek(SeekFrom::End(0))
+                file.seek(SeekFrom::Start(0))
                     .map_err(|e| format!("Failed to seek to start of file: {file_path}, {e}"))?;
                 file.write_all(&encoded_output)
                     .map_err(|e| format!("Failed to write to '{file_path}', {e}"))?;
+                file.set_len(encoded_output.len() as u64)
+                    .map_err(|e| format!("Failed to set file length: {file_path}, {e}"))?;
                 Ok(())
             },
         )


### PR DESCRIPTION
Truncating after writing all the bytes is up to 20% faster than truncating before (depending on the file size distribution), according to our benchmarks on my machine.

```text
submodules/Indy         time:   [3.1786 ms 3.2340 ms 3.2998 ms]
                        change: [-22.823% -21.118% -19.039%] (p = 0.00 < 0.05)
                        Performance has improved.
submodules/DEC          time:   [43.477 ms 43.894 ms 44.326 ms]
                        change: [-2.6047% -1.1776% +0.3206%] (p = 0.11 > 0.05)
                        No change in performance detected.
```