### PR TITLE
Optimise Compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ members = [
 
 [profile.release]
 lto = true
+codegen-units = 1


### PR DESCRIPTION
Improves performance of the release build at the price of compile times.
* Enables LTO
* Sets `codegen-units` to 1

On my machine the combined performance improvements for the benchmarks are as follows:
```text
submodules/Indy         time:   [4.0399 ms 4.0959 ms 4.1565 ms]
                        change: [-3.6989% -1.9248% -0.1555%] (p = 0.04 < 0.05)
                        Change within noise threshold.
submodules/DEC          time:   [37.767 ms 38.414 ms 39.100 ms]
                        change: [-15.898% -14.123% -12.307%] (p = 0.00 < 0.05)
                        Performance has improved.
```