### PR TITLE
Lint all targets and features

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,6 @@ repos:
         language: system
         types: [rust]
         args: ["--"]
-      - id: cargo-check
-        name: cargo check
-        description: Check the package for errors.
-        entry: cargo check
-        language: system
-        types: [rust]
-        pass_filenames: false
       - id: clippy
         name: clippy
         description: Lint rust sources


### PR DESCRIPTION
- add `--workspace`, `--all-targets`, and `--all-features` flags to make `clippy` lint all code (in particular this includes benchmark and tests)
- remove `cargo check` from pre-commit because all of its warnings and errors will also be raised by `clippy`