### PR TITLE
Fix formatting toggle behaviour around conditional directives

### DIFF
--- a/core/src/defaults/reconstructor.rs
+++ b/core/src/defaults/reconstructor.rs
@@ -20,7 +20,7 @@ impl LogicalLinesReconstructor for DelphiLogicalLinesReconstructor {
             .iter()
             .sorted_by_key(|(token, _)| token.get_index())
             .for_each(|(token, formatting_data)| {
-                if formatting_data.ignored {
+                if formatting_data.is_ignored() {
                     out.push_str(token.get_leading_whitespace());
                 } else {
                     (0..formatting_data.newlines_before)
@@ -58,10 +58,7 @@ mod tests {
     }
 
     fn ignored_formatting_data() -> FormattingData {
-        FormattingData {
-            ignored: true,
-            ..Default::default()
-        }
+        FormattingData::from(("", true))
     }
 
     #[test]
@@ -83,14 +80,10 @@ mod tests {
 
     #[test]
     fn all_tokens_with_data_constructed_spaces() {
-        let formatting_data1 = FormattingData {
-            spaces_before: 3,
-            ..Default::default()
-        };
-        let formatting_data2 = FormattingData {
-            spaces_before: 1,
-            ..Default::default()
-        };
+        let mut formatting_data1 = FormattingData::default();
+        formatting_data1.spaces_before = 3;
+        let mut formatting_data2 = FormattingData::default();
+        formatting_data2.spaces_before = 1;
         run_test(
             FormattedTokens::new(vec![
                 (
@@ -108,14 +101,10 @@ mod tests {
 
     #[test]
     fn all_tokens_with_data_constructed_indentations() {
-        let formatting_data1 = FormattingData {
-            indentations_before: 3,
-            ..Default::default()
-        };
-        let formatting_data2 = FormattingData {
-            indentations_before: 1,
-            ..Default::default()
-        };
+        let mut formatting_data1 = FormattingData::default();
+        formatting_data1.indentations_before = 3;
+        let mut formatting_data2 = FormattingData::default();
+        formatting_data2.indentations_before = 1;
         run_test(
             FormattedTokens::new(vec![
                 (
@@ -133,14 +122,10 @@ mod tests {
 
     #[test]
     fn all_tokens_with_data_constructed_continuations() {
-        let formatting_data1 = FormattingData {
-            continuations_before: 3,
-            ..Default::default()
-        };
-        let formatting_data2 = FormattingData {
-            continuations_before: 1,
-            ..Default::default()
-        };
+        let mut formatting_data1 = FormattingData::default();
+        formatting_data1.continuations_before = 3;
+        let mut formatting_data2 = FormattingData::default();
+        formatting_data2.continuations_before = 1;
         run_test(
             FormattedTokens::new(vec![
                 (
@@ -158,10 +143,8 @@ mod tests {
 
     #[test]
     fn some_tokens_with_data() {
-        let formatting_data1 = FormattingData {
-            newlines_before: 3,
-            ..Default::default()
-        };
+        let mut formatting_data1 = FormattingData::default();
+        formatting_data1.newlines_before = 3;
         run_test(
             FormattedTokens::new(vec![
                 (
@@ -175,10 +158,8 @@ mod tests {
             ]),
             "\n\n\ntoken1\n   token2",
         );
-        let formatting_data2 = FormattingData {
-            newlines_before: 3,
-            ..Default::default()
-        };
+        let mut formatting_data2 = FormattingData::default();
+        formatting_data2.newlines_before = 3;
         run_test(
             FormattedTokens::new(vec![
                 (

--- a/core/src/traits.rs
+++ b/core/src/traits.rs
@@ -1,5 +1,4 @@
-use std::collections::HashSet;
-
+use crate::formatter::TokenMarker;
 use crate::lang::*;
 
 pub trait Lexer {
@@ -18,8 +17,12 @@ pub trait LogicalLinesConsolidator {
     fn consolidate(&self, input: (&mut [Token], &mut [LogicalLine]));
 }
 
+pub trait TokenIgnorer {
+    fn ignore_tokens(&self, input: (&[Token], &[LogicalLine]), token_marker: &mut TokenMarker);
+}
+
 pub trait TokenRemover {
-    fn remove_tokens(&self, input: (&[Token], &[LogicalLine]), marked_tokens: &mut HashSet<usize>);
+    fn remove_tokens(&self, input: (&[Token], &[LogicalLine]), token_marker: &mut TokenMarker);
 }
 
 pub trait LogicalLineFormatter {

--- a/front-end/src/lib.rs
+++ b/front-end/src/lib.rs
@@ -44,7 +44,7 @@ pub fn format_with_settings(formatting_settings: FormattingSettings, config: Pas
             .lines_consolidator(PropertyDeclarationConsolidator {})
             .token_consolidator(DistinguishGenericTypeParamsConsolidator {})
             .lines_consolidator(UsesClauseConsolidator {})
-            .file_formatter(FormattingToggler {})
+            .token_ignorer(FormattingToggler {})
             .file_formatter(TokenSpacing {})
             .line_formatter(RemoveRepeatedNewlines {})
             .line_formatter(FormatterSelector::new(


### PR DESCRIPTION
The formatting toggle should work with the literal token stream, not the logical lines. The user would expect the ignored code to be exactly the tokens visible between the start and end comments in the source code, rather than in the expanded conditional code.