### PR TITLE
Parse visibility specifiers to their own line

### DIFF
--- a/core/src/defaults/parser.rs
+++ b/core/src/defaults/parser.rs
@@ -140,7 +140,7 @@ impl<'a> InternalDelphiLogicalLineParser<'a> {
                 Keyword(Property) => {
                     self.parse_property_declaration();
                 }
-                IdentifierOrKeyword(Private | Protected | Public | Published) => {
+                IdentifierOrKeyword(Private | Protected | Public | Published | Automated) => {
                     self.add_logical_line();
                     self.next_token();
                     self.add_logical_line();
@@ -245,7 +245,16 @@ impl<'a> InternalDelphiLogicalLineParser<'a> {
                     self.add_logical_line();
                     return;
                 }
-                IdentifierOrKeyword(Private | Protected | Public | Published) => {
+                Keyword(Class) => {
+                    // If class is the first token in the line, allow the next
+                    // token to dictate how it will be parsed.
+                    self.next_token();
+                }
+                Keyword(Property) => {
+                    self.parse_property_declaration();
+                    return;
+                }
+                IdentifierOrKeyword(Private | Protected | Public | Published | Automated) => {
                     self.add_logical_line();
                     self.next_token();
                     self.add_logical_line();
@@ -1031,6 +1040,14 @@ mod tests {
             vec![
                 LogicalLine::new(None, 0, vec![0], LogicalLineType::Unknown),
                 LogicalLine::new(None, 0, vec![1, 2], LogicalLineType::PropertyDeclaration),
+            ],
+        );
+        run_test(
+            "strict private property Foo",
+            vec![
+                LogicalLine::new(None, 0, vec![0], LogicalLineType::Unknown),
+                LogicalLine::new(None, 0, vec![1], LogicalLineType::Unknown),
+                LogicalLine::new(None, 0, vec![2, 3], LogicalLineType::PropertyDeclaration),
             ],
         );
         run_test(


### PR DESCRIPTION
Without parsing visibility specifiers on their own line, the following property declaration line was not getting correctly annotated. This annotation is then used to update the `TokenType` to aid in formatting.

The property declaration parsing and consolidation can go about their businesses as usual if the visibility specifiers are to be on their own line.

This change will be overridden in future when a greater understanding of type declarations is implemented.