### PR TITLE
Remove extra trailing newline when formatting stdin to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Incorrect parsing for generic type param lists containing semicolons.
+- Extra trailing newline when formatting stdin to stdout.
 
 ## [0.1.0] - 2023-08-28
 

--- a/orchestrator/src/file_formatter.rs
+++ b/orchestrator/src/file_formatter.rs
@@ -124,13 +124,15 @@ impl FileFormatter {
     }
     pub fn format_stdin_to_stdout(&self, input: &str) {
         let formatted_input = self.formatter.format(input);
-        println!("{}", formatted_input);
+        print!("{}", formatted_input);
     }
     pub fn format_files_to_stdout<S: AsRef<str>>(&self, paths: &[S]) {
         self.exec_format(
             paths,
             OpenOptions::new(),
             |_, file_path, _, formatted_output| {
+                // Append a newline to the formatted output deliberately because makes it more
+                // human-readable and no less machine-readable.
                 println!("{}:\n{}", file_path.to_string_lossy(), formatted_output);
                 Ok(())
             },


### PR DESCRIPTION
The `println!` macro was used when printing the result of formatting stdin. This added a newline character to the output stream which otherwise contained exactly the formatted file contents. When using the formatter with IDE integrations it's important for stdout to be exactly as intended.