### PR TITLE
Use feature resolver version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ members = [
     "front-end",
 ]
 
+resolver = "2"
+
 [profile.release]
 lto = true
 codegen-units = 1


### PR DESCRIPTION
This resolves the warning cargo has been emitting for a while regarding having to fall back to the old feature resolver version.

Using the new resolver version doesn't seem to affect us, but it's better to be with the new version since it's the default for edition 2021 Rust (but not for virtual workspaces for some reason).

See
- https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
- https://github.com/rust-lang/cargo/issues/10112