### PR TITLE
Only write to files when the contents need changing

### DIFF
--- a/orchestrator/src/file_formatter.rs
+++ b/orchestrator/src/file_formatter.rs
@@ -108,7 +108,11 @@ impl FileFormatter {
         self.exec_format(
             paths,
             OpenOptions::new().write(true).to_owned(),
-            |file, file_path, _, formatted_output| {
+            |file, file_path, file_contents, formatted_output| {
+                if file_contents.eq(&formatted_output) {
+                    debug!("Skipping writing to '{file_path:?}' because it is already formatted.");
+                    return Ok(());
+                }
                 let path_str = || file_path.to_string_lossy();
                 let encoded_output = self.encoding.encode(&formatted_output).0;
                 file.seek(SeekFrom::Start(0)).map_err(|e| {


### PR DESCRIPTION
One of the main use cases for this tool is incremental formatting on large repositories. In such cases, writing to every file on every format is quite wasteful because it requires the version control system to re-index all files. To save this time in VCS indexing, we can spend a little time checking whether a file needs changing before writing to it.

This string comparison is comparatively very fast and significantly improves performance in the incremental case (15-40% faster overall in our benchmarks on my machine). When files need to be changed it should be slower overall, but the impact was not measurable on my machine.