### PR TITLE
Remove dependency on `nom`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,22 +512,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,7 +566,6 @@ dependencies = [
  "itertools 0.11.0",
  "log",
  "memchr",
- "nom",
  "paste",
  "rand",
  "spectral",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 itertools = "0.11.0"
-nom = "7.1.3"
 log = "0.4"
 memchr = "2.6.0"
 cfg-if = "1.0.0"


### PR DESCRIPTION
It was originally used mainly for lexing, but that has now been rewritten without the dependence on `nom`. Now, the only other use is in `formatting_toggle.rs` but it's too trivial to be worth the dependency.