### PR TITLE
Review keyword list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `string` as a keyword
 
+### Removed
+
+- `add`, `remove`, and `variant` as keywords
+
 ### Fixed
 
 - Incorrect parsing for generic type param lists containing semicolons.

--- a/core/src/defaults/lexer.rs
+++ b/core/src/defaults/lexer.rs
@@ -314,10 +314,9 @@ const fn make_byte_map<T: Copy>(map: &[(ByteSet<'_>, T)], default: T) -> [T; 256
 // endregion: byte-set
 
 // region: keywords
-const KEYWORDS: [(&str, TokenType); 124] = [
+const KEYWORDS: [(&str, TokenType); 121] = [
     ("absolute", TT::IdentifierOrKeyword(KK::Absolute)),
     ("abstract", TT::IdentifierOrKeyword(KK::Abstract)),
-    ("add", TT::IdentifierOrKeyword(KK::Add)),
     ("align", TT::IdentifierOrKeyword(KK::Align)),
     ("and", TT::Keyword(KK::And)),
     ("array", TT::Keyword(KK::Array)),
@@ -406,7 +405,6 @@ const KEYWORDS: [(&str, TokenType); 124] = [
     ("reference", TT::IdentifierOrKeyword(KK::Reference)),
     ("register", TT::IdentifierOrKeyword(KK::Register)),
     ("reintroduce", TT::IdentifierOrKeyword(KK::Reintroduce)),
-    ("remove", TT::IdentifierOrKeyword(KK::Remove)),
     ("repeat", TT::Keyword(KK::Repeat)),
     ("requires", TT::IdentifierOrKeyword(KK::Requires)),
     ("resident", TT::IdentifierOrKeyword(KK::Resident)),
@@ -432,7 +430,6 @@ const KEYWORDS: [(&str, TokenType); 124] = [
     ("uses", TT::Keyword(KK::Uses)),
     ("var", TT::Keyword(KK::Var)),
     ("varargs", TT::IdentifierOrKeyword(KK::VarArgs)),
-    ("variant", TT::IdentifierOrKeyword(KK::Variant)),
     ("virtual", TT::IdentifierOrKeyword(KK::Virtual)),
     ("while", TT::Keyword(KK::While)),
     ("with", TT::Keyword(KK::With)),
@@ -1599,7 +1596,6 @@ mod tests {
         [
             ("absolute", TT::IdentifierOrKeyword(KK::Absolute)),
             ("abstract", TT::IdentifierOrKeyword(KK::Abstract)),
-            ("add", TT::IdentifierOrKeyword(KK::Add)),
             ("align", TT::IdentifierOrKeyword(KK::Align)),
             ("and", TT::Keyword(KK::And)),
             ("array", TT::Keyword(KK::Array)),
@@ -1687,7 +1683,6 @@ mod tests {
             ("reference", TT::IdentifierOrKeyword(KK::Reference)),
             ("register", TT::IdentifierOrKeyword(KK::Register)),
             ("reintroduce", TT::IdentifierOrKeyword(KK::Reintroduce)),
-            ("remove", TT::IdentifierOrKeyword(KK::Remove)),
             ("repeat", TT::Keyword(KK::Repeat)),
             ("requires", TT::IdentifierOrKeyword(KK::Requires)),
             ("resident", TT::IdentifierOrKeyword(KK::Resident)),
@@ -1713,7 +1708,6 @@ mod tests {
             ("uses", TT::Keyword(KK::Uses)),
             ("var", TT::Keyword(KK::Var)),
             ("varargs", TT::IdentifierOrKeyword(KK::VarArgs)),
-            ("variant", TT::IdentifierOrKeyword(KK::Variant)),
             ("virtual", TT::IdentifierOrKeyword(KK::Virtual)),
             ("while", TT::Keyword(KK::While)),
             ("with", TT::Keyword(KK::With)),

--- a/core/src/lang.rs
+++ b/core/src/lang.rs
@@ -73,7 +73,6 @@ pub enum KeywordKind {
     // Impure keywords
     Absolute,
     Abstract,
-    Add,
     Align,
     Assembler,
     At,
@@ -116,7 +115,6 @@ pub enum KeywordKind {
     Reference,
     Register,
     Reintroduce,
-    Remove,
     Requires,
     Resident,
     SafeCall,
@@ -127,7 +125,6 @@ pub enum KeywordKind {
     Strict,
     Unsafe,
     VarArgs,
-    Variant,
     Virtual,
     Write,
     WriteOnly,

--- a/misc/generate_keyword_hash_fn.sh
+++ b/misc/generate_keyword_hash_fn.sh
@@ -5,7 +5,6 @@ gperf -m 100 "$@" <<EOF
 %%
 absolute
 abstract
-add
 align
 and
 array
@@ -94,7 +93,6 @@ record
 reference
 register
 reintroduce
-remove
 repeat
 requires
 resident
@@ -120,7 +118,6 @@ until
 uses
 var
 varargs
-variant
 virtual
 while
 with


### PR DESCRIPTION
### Added

- `string` as a keyword

Initially we thought that we wouldn't treat `string` as a keyword because we wanted to have it formatted like an identifier. This was bad idea because it's much more important to have the core tool classify tokens correctly, and it's always possible for a formatter to decide to make a special case for `string`.

### Removed

- `add`, `remove`, and `variant` as keywords

These were erroneously copied over from an old version of a Delphi grammar; they are not real keywords in any context.