### PR TITLE
Support Delphi 12 multiline string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `string` as a keyword
+- Support for Delphi 12 multi-line string literals
 
 ### Removed
 


### PR DESCRIPTION
Implements support for multiline string literals from Delphi 12.
- [blog](https://blogs.embarcadero.com/yukon-beta-blog-delphi-language-modernizing-string-literals/)
- [docs](https://docwiki.embarcadero.com/RADStudio/Athens/e/index.php/String_Types_(Delphi)#Long_and_Multiline_String_Literals)

Note: the docs do not mention the flexibility in number of quote characters used that the blog post describes (and the compiler implements).