### PR TITLE
Distinguish text literal kinds in lexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `add`, `remove`, and `variant` as keywords
 
+### Changed
+
+- `TokenType::TextLiteral` to contain a `TextLiteralKind`.
+
 ### Fixed
 
 - Incorrect parsing for generic type param lists containing semicolons.

--- a/core/src/lang.rs
+++ b/core/src/lang.rs
@@ -188,12 +188,20 @@ pub enum ConditionalDirectiveKind {
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum TextLiteralKind {
+    SingleLine,
+    MultiLine,
+    Asm,
+    Unterminated,
+}
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum TokenType {
     Op(OperatorKind),
     Identifier,
     IdentifierOrKeyword(KeywordKind),
     Keyword(KeywordKind),
-    TextLiteral,
+    TextLiteral(TextLiteralKind),
     NumberLiteral(NumberLiteralKind),
     ConditionalDirective(ConditionalDirectiveKind),
     CompilerDirective,

--- a/core/src/rules/uses_clause_formatter.rs
+++ b/core/src/rules/uses_clause_formatter.rs
@@ -84,7 +84,7 @@ impl LogicalLineFormatter for UsesClauseFormatter {
                 formatted_tokens.get_token_type_for_index(token_index),
                 Some(
                     TokenType::Keyword(KeywordKind::In)
-                        | TokenType::TextLiteral
+                        | TokenType::TextLiteral(_)
                         | TokenType::Comment(_)
                 )
             ) || token_index > 1


### PR DESCRIPTION
There are several kinds of 'text literals' that are all currently lexed to the same token type with no way to distinguish them later.
No built-in formatters currently do anything with text literals, but any were to try they would have to identify which kind of literal they are dealing with.

For example
- When we start wrapping lines, it will be important to know whether a text literal was unterminated - so that the trailing newline is preserved. 
- When (and if) we start formatting text literals themselves, multi-line literals would likely have completely different rules to single-line ones.

This PR changes the `TokenType::TextLiteral` variant to contain a `TextLiteralKind` which distinguishes between single-line, multi-line, asm, and unterminated text literals.