### PR TITLE
Lex caret-escaped characters correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Incorrect lexing of asm blocks
     - Asm labels can now start with just one '@' character instead of two, and they can contain '@' characters.
     - Asm integer literals now supported (e.g. octal `076O`, hex `0FFH`/`$FF`, binary `010B`)
+- Lexing of legacy caret-escaped character literals
 
 ## [0.1.0] - 2023-08-28
 

--- a/core/src/lang.rs
+++ b/core/src/lang.rs
@@ -210,6 +210,17 @@ pub enum TokenType {
     Unknown,
 }
 
+impl TokenType {
+    pub(crate) fn is_hidden(&self) -> bool {
+        matches!(
+            self,
+            TokenType::Comment(_)
+                | TokenType::CompilerDirective
+                | TokenType::ConditionalDirective(_)
+        )
+    }
+}
+
 #[derive(Debug, Hash, PartialEq, Eq, Copy, Clone)]
 pub enum LogicalLineType {
     ConditionalDirective,

--- a/core/src/rules/token_spacing.rs
+++ b/core/src/rules/token_spacing.rs
@@ -304,7 +304,6 @@ mod tests {
 
     formatter_test_group!(
         pointer,
-        pointer_before = {"if  ^ Foo then", "if ^Foo then"},
         pointer_after = {"if Foo ^ then", "if Foo^ then"},
         pointer_after_parens = {"if Foo() ^ then", "if Foo()^ then"},
         pointer_after_brackets = {"if Foo[] ^then", "if Foo[]^ then"},
@@ -316,8 +315,6 @@ mod tests {
         double_pointer_before_brackets = {"Foo^ ^ [Bar]", "Foo^^[Bar]"},
         double_pointer_after_parens = {"Foo()  ^  ^", "Foo()^^"},
         double_pointer_after_brackets = {"Foo[0]   ^ ^", "Foo[0]^^"},
-        double_pointer_before_ident = {"type Foo = ^ ^ Bar", "type Foo = ^^Bar"},
-        triple_pointer_before_ident = {"type Foo = ^ ^ ^ Bar", "type Foo = ^^^Bar"},
         triple_pointer_after_ident = {"Foo  ^ ^ ^", "Foo^^^"},
     );
 


### PR DESCRIPTION
Delphi supports this undocumented feature of 'caret-escaped' characters carried forward from Turbo Pascal.
We have to lex these as text literals to ensure valid formatting of the code.

See [sonar-delphi#111](https://github.com/integrated-application-development/sonar-delphi/issues/111) for some details on the implementation.