### PR TITLE
Print message to stderr when reading from a terminal's stdin

### DIFF
--- a/orchestrator/src/formatting_orchestrator.rs
+++ b/orchestrator/src/formatting_orchestrator.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::io::{IsTerminal, Read};
 
 use crate::file_formatter::FileFormatter;
 use log::LevelFilter;
@@ -16,6 +16,9 @@ impl FormattingOrchestrator {
         let files = config.get_paths();
         if files.is_empty() {
             let mut input = String::new();
+            if std::io::stdin().is_terminal() {
+                eprintln!("waiting for stdin...");
+            }
             let mut stdin = std::io::stdin().lock();
 
             stdin.read_to_string(&mut input).unwrap();


### PR DESCRIPTION
If a user were to run `pasfmt` with no additional arguments, it would (perhaps unexpectedly) hang waiting for input on stdin.

To be a bit more friendly, this PR adds a check for whether stdin is a terminal before attempting to read from it. In the case of a terminal as stdin it now outputs the message `waiting for stdin...` to stderr.