### PR TITLE
Add support for overriding configuration options on the command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `string` as a keyword
 - Support for Delphi 12 multi-line string literals
+- `-C` CLI option to override configuration options.
 
 ### Removed
 
 - `add`, `remove`, and `variant` as keywords
+- short version of `--config-file` CLI option
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+
+[[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +123,12 @@ name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+
+[[package]]
+name = "bytemuck"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
 
 [[package]]
 name = "cast"
@@ -356,6 +377,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "figment"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6e5bc7bd59d60d0d45a6ccab6cf0f4ce28698fb4e81e750ddf229c9b824026"
+dependencies = [
+ "atomic",
+ "serde",
+ "toml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +590,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 name = "pasfmt"
 version = "0.2.0-dev"
 dependencies = [
+ "anyhow",
  "codepage",
  "criterion",
  "encoding_rs",
@@ -589,12 +624,15 @@ dependencies = [
 name = "pasfmt-orchestrator"
 version = "0.2.0-dev"
 dependencies = [
+ "anyhow",
  "clap",
  "encoding_rs",
+ "figment",
  "glob",
  "log",
  "pasfmt-core",
  "rayon",
+ "serde",
  "toml",
  "walkdir",
  "yare",
@@ -806,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
 ]
@@ -891,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -903,24 +941,33 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.14"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -934,6 +981,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"

--- a/front-end/Cargo.toml
+++ b/front-end/Cargo.toml
@@ -11,6 +11,7 @@ serde = "1.0.164"
 serde_derive = "1.0.164"
 stderrlog = "0.5.4"
 log = "0.4"
+anyhow = "1.0.79"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.52.0", features = ["Win32_Globalization"] }

--- a/front-end/src/lib.rs
+++ b/front-end/src/lib.rs
@@ -3,7 +3,7 @@
 use encoding_rs::Encoding;
 use pasfmt_core::prelude::*;
 use pasfmt_orchestrator::predule::*;
-use serde_derive::Deserialize;
+use serde_derive::{Deserialize, Serialize};
 
 #[cfg(windows)]
 fn windows_default_encoding() -> &'static Encoding {
@@ -31,7 +31,7 @@ fn default_encoding() -> &'static Encoding {
     encoding_rs::UTF_8
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct FormattingSettings {
     reconstruction: Reconstruction,
     encoding: &'static Encoding,
@@ -56,7 +56,7 @@ impl From<Reconstruction> for ReconstructionSettings {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 struct Reconstruction {
     eol: String,
     indentation: String,

--- a/front-end/src/main.rs
+++ b/front-end/src/main.rs
@@ -4,13 +4,14 @@ use pasfmt_orchestrator::predule::*;
 
 pasfmt_config!(Config);
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let config = Config::create();
     stderrlog::new()
         .verbosity(config.log_level())
         .init()
         .unwrap();
 
-    let formatting_settings = config.get_config_object::<FormattingSettings>();
+    let formatting_settings = config.get_config_object::<FormattingSettings>()?;
     format_with_settings(formatting_settings, config);
+    Ok(())
 }

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -9,9 +9,12 @@ encoding_rs = "0.8.32"
 glob = "0.3.1"
 pasfmt-core = { path = "../core" }
 rayon = "1.7.0"
-toml = "0.7.5"
+toml = "0.8.8"
 walkdir = "2.3.3"
 log = "0.4"
+serde = "1.0.164"
+figment = { version = "0.10.14", features = ["toml"] }
+anyhow = "1.0.79"
 
 [dev-dependencies]
 yare = "1.0.2"


### PR DESCRIPTION
This PR add support for overriding generic configuration options on the command line.
For example: `-C encoding=utf-8`.

Options provided this way override the options read from the TOML file.