### PR TITLE
Replace arguments to `pasfmt_config!` with generic `:meta` arguments

### DIFF
--- a/orchestrator/src/command_line.rs
+++ b/orchestrator/src/command_line.rs
@@ -18,9 +18,10 @@ const DEFAULT_CONFIG_FILE_NAME: &str = "pasfmt.toml";
 
 #[macro_export]
 macro_rules! pasfmt_config {
-    ($type_name: ident $(, name = $name: expr, version = $version: expr)?) => {
+    ($(#[$attr: meta])* $type_name: ident) => {
         #[derive(clap::Parser, Debug)]
-        #[command($(name = $name,)? author, about, version $(= $version)?, long_about = None)]
+        #[command(author, about, version, long_about = None)]
+        $(#[$attr])*
         struct $type_name {
             #[command(flatten)]
             config: PasFmtConfiguration,


### PR DESCRIPTION
This means that the user can freely specify whatever attributes they want and they will be applied to the generated struct.

For example
```rust
pasfmt_config!(
  #[command(name = "foo")]
  #[command(version = "1.0")]
  #[command(author = "me")]
  Config
)
```

will set the name to "foo", the version to "1.0", and the author name to "me", all without committing to any kind of interface in the macro.