### PR TITLE
Revert to default release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,3 @@ members = [
 ]
 
 resolver = "2"
-
-[profile.release]
-lto = true
-codegen-units = 1


### PR DESCRIPTION
Reviewing the benchmarks, the performance differences are too minor to justify the increase in compile times.

Compile times with full LTO and codegen-units=1 are about 20s for the best-case incremental compile. Whereas they are as low as 3.5s with the default release profile.

The performance differences in my latest benchmarks are on the order of 1-2%.