### PR TITLE
Fix lexing of `..` operator after integer literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Incorrect lexing of asm blocks
     - Asm labels can now start with just one '@' character instead of two, and they can contain '@' characters.
     - Asm integer literals now supported (e.g. octal `076O`, hex `0FFH`/`$FF`, binary `010B`)
+  - Incorrect lexing of `..` tokens used directly after integer literals (e.g. `0..1`).
 - Incorrect encoding used for writing files with encodings inferred from a BOM.
 - Incorrect encoding used in stdin/stdout mode; UTF-8 was always used, but now the configured
   encoding is respected.


### PR DESCRIPTION
Currently `1..2` would be lexed as the numeric literal `1.` followed by `.`, then `2`.
This was a result of an attempt to be liberal in the kinds of invalid code we accept, but this leads to valid code being lexed incorrectly.