### PR TITLE
Reuse allocations for input and output in `file_formatter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Can be used in stdin/stdout mode.
   - Messages for incorrectly formatted files prefixed with 'CHECK' instead of 'VERIFY', and are
     sent to stderr, not stdout.
+- `Formatter::format_into_buf` and `Reconstructor::reconstruct_into_buf` to allow reuse of memory
+  allocations.
 
 ### Removed
 

--- a/core/src/defaults/reconstructor.rs
+++ b/core/src/defaults/reconstructor.rs
@@ -11,29 +11,27 @@ impl DelphiLogicalLinesReconstructor {
     }
 }
 impl LogicalLinesReconstructor for DelphiLogicalLinesReconstructor {
-    fn reconstruct(&self, formatted_tokens: FormattedTokens) -> String {
-        let mut out = String::new();
+    fn reconstruct_into_buf(&self, formatted_tokens: FormattedTokens, buf: &mut String) {
         formatted_tokens
             .get_tokens()
             .iter()
             .for_each(|(token, formatting_data)| {
                 if formatting_data.is_ignored() {
-                    out.push_str(token.get_leading_whitespace());
+                    buf.push_str(token.get_leading_whitespace());
                 } else {
                     (0..formatting_data.newlines_before)
-                        .for_each(|_| out.push_str(self.reconstruction_settings.get_newline_str()));
+                        .for_each(|_| buf.push_str(self.reconstruction_settings.get_newline_str()));
                     (0..formatting_data.indentations_before).for_each(|_| {
-                        out.push_str(self.reconstruction_settings.get_indentation_str())
+                        buf.push_str(self.reconstruction_settings.get_indentation_str())
                     });
                     (0..formatting_data.continuations_before).for_each(|_| {
-                        out.push_str(self.reconstruction_settings.get_continuation_str())
+                        buf.push_str(self.reconstruction_settings.get_continuation_str())
                     });
-                    (0..formatting_data.spaces_before).for_each(|_| out.push(' '));
+                    (0..formatting_data.spaces_before).for_each(|_| buf.push(' '));
                 };
 
-                out.push_str(token.get_content());
+                buf.push_str(token.get_content());
             });
-        out
     }
 }
 

--- a/core/src/formatter.rs
+++ b/core/src/formatter.rs
@@ -60,6 +60,11 @@ impl Formatter {
         FormatterBuilder::default()
     }
     pub fn format(&self, input: &str) -> String {
+        let mut out = String::new();
+        self.format_into_buf(input, &mut out);
+        out
+    }
+    pub fn format_into_buf(&self, input: &str, buf: &mut String) {
         let mut tokens = self.lexer.lex(input);
         for token_consolidator in self.token_consolidators.iter() {
             token_consolidator.consolidate(&mut tokens);
@@ -88,7 +93,8 @@ impl Formatter {
         for formatter in self.logical_line_formatters.iter() {
             formatter.format(&mut formatted_tokens, &lines);
         }
-        self.reconstructor.reconstruct(formatted_tokens)
+        self.reconstructor
+            .reconstruct_into_buf(formatted_tokens, buf);
     }
 }
 

--- a/core/src/traits.rs
+++ b/core/src/traits.rs
@@ -33,5 +33,10 @@ pub trait LogicalLineFileFormatter {
 }
 
 pub trait LogicalLinesReconstructor {
-    fn reconstruct(&self, formatted_tokens: FormattedTokens) -> String;
+    fn reconstruct_into_buf(&self, formatted_tokens: FormattedTokens, out: &mut String);
+    fn reconstruct(&self, formatted_tokens: FormattedTokens) -> String {
+        let mut out = String::new();
+        self.reconstruct_into_buf(formatted_tokens, &mut out);
+        out
+    }
 }


### PR DESCRIPTION
In our benchmarks this amounts to about a 5% overall performance improvement on my machine.

The only downside to this is that memory allocated for large files will be held onto for longer than necessary. Given that memory usage is pretty low overall (aligning pretty closely with the size of files used), and speed is a higher priority for us right now than memory usage, I think this is a worthwhile tradeoff.