### PR TITLE
Use `std::borrow::Cow` for token content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- `RefToken` and `OwningToken` types.
+
+### Changed
+
+- `Token` type to be a struct containing a `std::borrow::Cow` for the token content instead of
+  an enum of `RefToken` and `OwningToken`.
+
 ### Fixed
 
 - Missing `winapi` keyword.

--- a/core/src/formatter.rs
+++ b/core/src/formatter.rs
@@ -689,7 +689,7 @@ mod tests {
                     if token.get_token_type() != TokenType::Identifier {
                         return;
                     }
-                    *token = Token::RefToken(RefToken::new("1", 0, token.get_token_type()));
+                    *token = Token::new_ref("1", 0, token.get_token_type());
                 }
             });
         }

--- a/core/src/test_utils.rs
+++ b/core/src/test_utils.rs
@@ -31,14 +31,14 @@ fn ws_len(whitespace_and_content: &str) -> u32 {
 }
 
 pub fn new_token(whitespace_and_content: &str, token_type: TokenType) -> Token {
-    Token::RefToken(RefToken::new(
+    Token::new_ref(
         whitespace_and_content,
         ws_len(whitespace_and_content),
         token_type,
-    ))
+    )
 }
 
 pub fn new_owning_token<'a>(whitespace_and_content: String, token_type: TokenType) -> Token<'a> {
     let ws_len = ws_len(&whitespace_and_content);
-    Token::OwningToken(OwningToken::new(whitespace_and_content, ws_len, token_type))
+    Token::new_owned(whitespace_and_content, ws_len, token_type)
 }


### PR DESCRIPTION
The resulting `Token` struct is the same 32 bytes in size, but is a bit simpler in implementation and use.
