### PR TITLE
Remove mention of core feature flag from `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   idempotent.
 - Colour styling in CLI help.
 - `RawTokenType` as a copy of `TokenType` with `IdentifierOrKeyword`.
-- `string-to-enum` feature to `core` for `KeywordKind` and `LogicalLineType`.
 
 ### Removed
 


### PR DESCRIPTION
This feature had been renamed and made "private" prior to being merged, making it incorrect and irrelevant.