### PR TITLE
Set `datatest` crate dependencies to test-only

### DIFF
--- a/core/datatests/Cargo.toml
+++ b/core/datatests/Cargo.toml
@@ -3,7 +3,7 @@ name = "datatests"
 version = "0.0.0"
 edition = "2021"
 
-[dependencies]
+[dev-dependencies]
 datatest-stable = { workspace = true }
 pasfmt-core = { path = "..", features = [ "_lang_types_from_str" ] }
 spectral = { workspace = true }


### PR DESCRIPTION
The dependencies being dragged in by the `datatest` crate in theworkspace were being enabled not just for a test build. Most notable, this was enabling the 'private' feature of the `core` crate that dragged in the `strum` and `strum-macros` crates, slowing down the build.
