### PR TITLE
Fix compiler directive nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Lexing of conditional directive expressions containing compiler directives, comments, or strings.
+- Lexing of compiler directives similar to conditional directives (e.g. `{$if_}`).
 
 ## [0.3.0] - 2024-05-29
 


### PR DESCRIPTION
- **Abbreviate compiler directive lexing tests using consts**
- **Fix lexing of nested compiler directives**
- **Fix lexical boundary for compiler directive names**
- **Optimise compiler directive identification**
