### PR TITLE
Fix parsing of repeated label definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `pasfmt.toml` file. It is now an error to provide a path to a directory.
 - Detection of decoding errors when reading from stdin.
 - Silent ignoral of non-existent paths (were being treated as globs matching no files).
+- Parsing of repeated label definitions.
 
 ## [0.3.0] - 2024-05-29
 

--- a/core/datatests/generators/logical_line_parser.rs
+++ b/core/datatests/generators/logical_line_parser.rs
@@ -33,6 +33,9 @@ macro_rules! generate_test_cases {
                 std::fs::create_dir_all(&dir)
                     .expect(&format!("failed to create all directories: {}", &dir.display()));
                 let file_name = dir.join(stringify!($name));
+                if file_name.exists() {
+                    panic!("Test with name {} already exists at {}", stringify!($name), file_name.display());
+                }
                 std::fs::write(&file_name, $input)
                     .expect(&format!("failed to write file `{}` for test", &file_name.display()));
             }
@@ -2509,8 +2512,70 @@ mod statements {
                 root_dir,
                 test_group,
                 goto_i = "goto Foo",
-                goto_n = "goto 1",
-                label = "Foo:"
+                goto_d = "goto 1",
+                goto_h = "goto $1",
+                goto_b = "goto %1",
+                label_i = "Foo:",
+                label_d = "1111:",
+                label_h = "$1111:",
+                label_b = "%1111:",
+            );
+            generate_test_cases!(
+                root_dir,
+                multi_label = "
+                    _|begin
+                    _|  Foo:
+                    _|  111:
+                    _|  $111:
+                    _|  %111:
+                    _|end
+                ",
+                i_label_statement = "
+                    _|begin
+                    _|  Foo:
+                    _|  Bar();
+                    _|end
+                ",
+                d_label_statement = "
+                    _|begin
+                    _|  111:
+                    _|  Bar();
+                    _|end
+                ",
+                b_label_statement = "
+                    _|begin
+                    _|  $111:
+                    _|  Bar();
+                    _|end
+                ",
+                h_label_statement = "
+                    _|begin
+                    _|  %111:
+                    _|  Bar();
+                    _|end
+                ",
+                other_contexts = "
+                    _|begin
+                    _|  repeat
+                    _|    111:
+                    _|  until True;
+                    _|  try
+                    _|    111:
+                    _|  except
+                    _|    111:
+                    _|  end;
+                    _|end;
+                    _|initialization
+                    _|  Foo:
+                    _|  111:
+                    _|  $111:
+                    _|  %111:
+                    _|finalization
+                    _|  Foo:
+                    _|  111:
+                    _|  $111:
+                    _|  %111:
+                ",
             );
         }
     }


### PR DESCRIPTION
In cases like:
```
begin
  Foo:
  Bar:
end;
```
The labels would be misinterpreted to be on the same logical line.

This change also ensures that any statements following the label will also be on their own line.