### PR TITLE
Fix failing tests in CI for windows

### DIFF
--- a/front-end/tests/idempotence.rs
+++ b/front-end/tests/idempotence.rs
@@ -1,6 +1,7 @@
 use assert_fs::{prelude::*, TempDir};
 use predicates::prelude::*;
 
+use crate::utils::windows::fmt_with_lock;
 use crate::utils::*;
 
 #[test]
@@ -10,30 +11,23 @@ fn file_is_only_written_when_necessary() -> TestResult {
     let to_leave = tmp.child("to_leave.pas");
     to_leave.write_str("a;")?;
     fmt(&*to_leave)?.success();
-    let to_leave_last_written = to_leave.metadata()?.modified()?;
 
     let to_change = tmp.child("to_change.pas");
     to_change.write_str("a ;")?;
-    let to_change_last_written = to_change.metadata()?.modified()?;
 
-    fmt(&*tmp)?
+    fmt_with_lock(&to_leave, 0)?
         .success()
         .stderr(predicate::str::contains(format!(
             "DEBUG Skipping writing to '{}' because it is already formatted.",
             to_leave.display()
         )));
 
-    assert_eq!(
-        to_leave.metadata()?.modified()?,
-        to_leave_last_written,
-        "File already in formatted state should not be written to"
-    );
-
-    assert_ne!(
-        to_change.metadata()?.modified()?,
-        to_change_last_written,
-        "File not already in formatted state should be written to"
-    );
+    fmt_with_lock(&to_change, 0)?
+        .failure()
+        .stderr(predicate::str::contains(format!(
+            "ERROR Failed to write to '{}'",
+            to_change.display()
+        )));
 
     Ok(())
 }

--- a/front-end/tests/tests.rs
+++ b/front-end/tests/tests.rs
@@ -4,6 +4,7 @@ mod config;
 mod encoding;
 mod file_discovery;
 mod help;
+#[cfg(windows)]
 mod idempotence;
 mod io_error;
 mod modes;

--- a/front-end/tests/utils.rs
+++ b/front-end/tests/utils.rs
@@ -17,3 +17,40 @@ pub fn fmt(
 pub type DynResult<T> = Result<T, Box<dyn std::error::Error>>;
 pub type TestResult = DynResult<()>;
 pub type AssertResult = DynResult<assert_cmd::assert::Assert>;
+
+#[cfg(windows)]
+pub mod windows {
+    use super::*;
+
+    use std::os::windows::io::AsRawHandle;
+    use std::path::Path;
+    use windows_sys::Win32::{
+        Storage::FileSystem::{LockFileEx, LOCK_FILE_FLAGS},
+        System::IO::OVERLAPPED,
+    };
+
+    pub fn fmt_with_lock(path: &Path, flags: LOCK_FILE_FLAGS) -> AssertResult {
+        let handle = std::fs::OpenOptions::new().write(true).open(path)?;
+        unsafe {
+            let mut overlapped: OVERLAPPED = std::mem::zeroed();
+            let ret = LockFileEx(
+                handle.as_raw_handle() as isize,
+                flags,
+                0,
+                !0,
+                !0,
+                &mut overlapped,
+            );
+
+            if ret == 0 {
+                return Err(Box::new(std::io::Error::last_os_error()));
+            }
+        }
+        // I don't think a guard to unlock the file is necessary, because the Microsoft docs say
+        //   If a process terminates with a portion of a file locked or closes a file that has
+        //   outstanding locks, the locks are unlocked by the operating system.
+        // And the file handle is closed at the end of this function.
+
+        Ok(fmt(path)?)
+    }
+}


### PR DESCRIPTION
Sometimes in CI the file timestamps don't update after a write to the
file. We don't know why exactly, but it probably has something to do
with their virtualisation or some deduping filesystem.

e.g. https://github.com/integrated-application-development/pasfmt/actions/runs/10590530822/job/29346465816#step:4:1159

Whatever the cause, it's clear we can't rely on timestamps to tell us
when files are touched; a more robust method is to lock the file and
assert that the operation fails as a result.
