### PR TITLE
Remove needless borrow from `encoding.rs`

### DIFF
--- a/front-end/tests/encoding.rs
+++ b/front-end/tests/encoding.rs
@@ -146,7 +146,7 @@ mod malformed {
     ) -> TestResult {
         pasfmt()?
             .write_stdin(data)
-            .arg(&format!("-Cencoding={encoding}"))
+            .arg(format!("-Cencoding={encoding}"))
             .assert()
             .failure()
             .stderr(predicate::str::contains(format!(


### PR DESCRIPTION
A new version of Clippy has added a warning for `needless borrowing for generic types`. This fixes the new warning in our project.