### PR TITLE
Fix orchestrator tests when `RUST_BACKTRACE` is set

### DIFF
--- a/orchestrator/src/command_line.rs
+++ b/orchestrator/src/command_line.rs
@@ -305,7 +305,6 @@ impl FormatterConfiguration for PasFmtConfiguration {
 mod tests {
     use super::*;
     use assert_fs::{prelude::*, TempDir};
-    use indoc::indoc;
     use serde_derive::{Deserialize, Serialize};
     use spectral::prelude::*;
 
@@ -464,7 +463,7 @@ mod tests {
                 config(&["", "--config-file=."])?.get_config_object();
             assert_that(&config).is_err();
             assert_eq!(
-                format!("{:?}", config.unwrap_err()),
+                format!("{:#}", config.unwrap_err()),
                 "Config file path cannot be a directory: '.'"
             );
 
@@ -583,14 +582,8 @@ mod tests {
             let obj: anyhow::Result<Settings, _> = config(&["", "-Casdf=0"])?.get_config_object();
             assert_that(&obj).is_err();
             assert_eq!(
-                format!("{:?}", obj.unwrap_err()),
-                indoc!(
-                    r#"
-                    Failed to construct configuration
-
-                    Caused by:
-                        Unknown configuration key "asdf" in command-line overrides"#
-                )
+                format!("{:#}", obj.unwrap_err()),
+                r#"Failed to construct configuration: Unknown configuration key "asdf" in command-line overrides"#
             );
 
             Ok(())


### PR DESCRIPTION
Some tests fail when `RUST_BACKTRACE` is set due to the way that anyhow formats the error using the
debug format modifier.

See https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations
