### PR TITLE
Fix parsing of mid-line compiler directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Silent ignoral of non-existent paths (were being treated as globs matching no files).
 - Parsing of repeated label definitions.
 - Consolidation of `in` as identifier in `class operator In` construct.
+- Duplicated line attribution of mid-line compiler directives.
 
 ## [0.3.0] - 2024-05-29
 

--- a/core/datatests/generators/logical_line_parser.rs
+++ b/core/datatests/generators/logical_line_parser.rs
@@ -189,6 +189,7 @@ mod directives {
                     ---
                     1:CompilerDirective
                 ",
+                mid_line = "_ |A {$J+} := B {$C+} + C {$C-};",
             );
         }
     }

--- a/core/src/defaults/parser.rs
+++ b/core/src/defaults/parser.rs
@@ -245,13 +245,9 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
                     self.skip_token()
                 }
                 kind @ (TT::Comment(_) | TT::CompilerDirective) => {
-                    if let Some(token_index) = self.get_current_token_index() {
-                        self.get_current_logical_line_mut().tokens.push(token_index);
-                        if let TT::CompilerDirective = kind {
-                            self.attributed_directives.insert(token_index);
-                            self.set_logical_line_type(LLT::CompilerDirective);
-                        }
-                        self.pass_index += 1;
+                    self.next_token(); // Comment/CompilerDirective
+                    if let TT::CompilerDirective = kind {
+                        self.set_logical_line_type(LLT::CompilerDirective);
                     }
                     let line_ref = self.get_current_logical_line_ref();
                     self.finish_logical_line();
@@ -1558,6 +1554,9 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
         loop {
             if let Some(token_index) = self.get_current_token_index() {
                 self.get_current_logical_line_mut().tokens.push(token_index);
+                if let Some(TT::CompilerDirective) = self.get_current_token_type() {
+                    self.attributed_directives.insert(token_index);
+                }
             }
 
             match self.get_current_token_type() {


### PR DESCRIPTION
There is a bug when compiling a line with compiler directives in the middle of the line. These tokens will both be attributed to the line they are within and their own separate line. When compiler directives are attributed to a line, they are supposed to effectively become inline block comments. This excludes them from the higher-level directive indentation and handling, etc.

E.g.,
`A := B {$C+} + C {$C-};`

Parses to these lines:
* `A := B {$C+} + C {$C-};`
* `{$C+}`
* `{$C-}`