### PR TITLE
Fix parsing of generic parameters in routine headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidation of `in` as identifier in `class operator In` construct.
 - Duplicated line attribution of mid-line compiler directives.
 - Parsing of `class helper`s with parent a type.
+- Parsing of generics parameters in routine headers.
 
 ## [0.3.0] - 2024-05-29
 

--- a/core/datatests/generators/logical_line_parser.rs
+++ b/core/datatests/generators/logical_line_parser.rs
@@ -1648,6 +1648,7 @@ mod routine_headers {
 
     pub fn generate(root_dir: &Path) {
         params::generate(root_dir);
+        generics::generate(root_dir);
         directives::generate(root_dir);
     }
 
@@ -1792,6 +1793,87 @@ mod routine_headers {
                 class_procedure = "class procedure",
                 constructor = "constructor",
                 destructor = "destructor",
+            );
+        }
+    }
+    mod generics {
+        use super::*;
+
+        macro_rules! test_group {
+            ($root_dir: expr, $input: expr) => {
+                generate_test_cases!(
+                    $root_dir,
+                    empty_list = format!( // This is invalid code
+                        "
+                            1|{} Foo<>;
+                            ---
+                            1:RoutineHeader
+                        ",
+                        $input
+                    ),
+                    comma_names = format!(
+                        "
+                            1|{} Foo<T, U, V>;
+                            ---
+                            1:RoutineHeader
+                        ",
+                        $input
+                    ),
+                    semi_names = format!(
+                        "
+                            1|{} Foo<T; U; V>;
+                            ---
+                            1:RoutineHeader
+                        ",
+                        $input
+                    ),
+                    constraints = format!(
+                        "
+                            1|{} Foo<T: record; U: constructor; V: object>;
+                            ---
+                            1:RoutineHeader
+                        ",
+                        $input
+                    ),
+                    comma_and_semi_names = format!(
+                        "
+                            1|{} Foo<T, U: record; V, W: constructor>();
+                            ---
+                            1:RoutineHeader
+                        ",
+                        $input
+                    ),
+                    with_param_list = format!(
+                        "
+                            1|{} Foo<T, U: record; V, W: constructor>(A: Integer; B: String);
+                            ---
+                            1:RoutineHeader
+                        ",
+                        $input
+                    ),
+                    generic_params = format!(
+                        "
+                            1|{} Foo<T, U: record; V, W: constructor>(
+                                  A: TDictionary<String, Integer>;
+                                  B: TFoo<T, U, V>
+                              );
+                            ---
+                            1:RoutineHeader
+                        ",
+                        $input
+                    ),
+                );
+            };
+        }
+
+        pub fn generate(root_dir: &Path) {
+            generate_test_groups!(
+                root_dir,
+                test_group,
+                function = "function",
+                class_function = "class function",
+                procedure = "procedure",
+                class_procedure = "class procedure",
             );
         }
     }

--- a/core/src/defaults/parser.rs
+++ b/core/src/defaults/parser.rs
@@ -1139,9 +1139,10 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
                         parser.parse_expression();
                     }
                 }
-                Some(TT::Op(OK::Semicolon))
-                    if parser.paren_level == 0 && parser.brack_level == 0 =>
-                {
+                Some(TT::Op(OK::LessThan(_))) => {
+                    parser.skip_pair();
+                }
+                Some(TT::Op(OK::Semicolon)) => {
                     parser.next_token();
                     parser.take_until(no_more_separators());
                     if parser


### PR DESCRIPTION
Previously, a line such as 
```delphi
procedure Apples<A; B; C>();
```
Would be parsed incorrectly due to the semicolon-separated generic arguments. The semicolon would erroneously terminate the _logical line_.