### PR TITLE
Fix parsing of anonymous routines with a trailing semicolon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parsing of `class helper`s with parent a type.
 - Parsing of generics parameters in routine headers.
 - Block comment kind for multiline comments on their own line.
+- Parsing of anonymous routines with trailing semicolons.
 
 ## [0.3.0] - 2024-05-29
 

--- a/core/datatests/generators/logical_line_parser.rs
+++ b/core/datatests/generators/logical_line_parser.rs
@@ -2675,6 +2675,8 @@ mod statements {
                 assign_l = "A := A + A * B",
                 assign_r = "A.B[C + D] := 0",
                 assign = "A.B[C + D] := E + F mod G",
+                anonymous_proc = "A := procedure begin end",
+                anonymous_func = "A := function: Boolean begin end",
             );
         }
     }

--- a/core/src/defaults/parser.rs
+++ b/core/src/defaults/parser.rs
@@ -650,6 +650,7 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
                             Some(TT::Keyword(KK::Asm)) => self.parse_asm_block(),
                             Some(TT::Keyword(KK::Begin)) => {
                                 self.parse_begin_end(false, 1);
+                                self.take_until(no_more_separators());
                                 self.finish_logical_line();
                             }
                             _ => {}
@@ -1400,7 +1401,6 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
             level_delta,
         });
         self.next_token(); // End
-        self.take_until(no_more_separators());
     }
     fn consolidate_portability_directives(&mut self) {
         fn get_token_type_of_line_index(


### PR DESCRIPTION
The parser would consume the semicolon as part of the routine, preventing the semicolon from terminating the line.
