### PR TITLE
Write formatted output to the console only as Unicode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parsing of generics parameters in routine headers.
 - Block comment kind for multiline comments on their own line.
 - Parsing of anonymous routines with trailing semicolons.
+- Errors on writing non-ASCII data in an ANSI encoding to a Windows Console. Now written as Unicode.
 
 ## [0.3.0] - 2024-05-29
 

--- a/front-end/tests/data/help/long_help_col.txt
+++ b/front-end/tests/data/help/long_help_col.txt
@@ -18,6 +18,8 @@
           The mode of operation
           
           The default is `files`, unless data is being read from stdin, in which case the default is `stdout`.
+          
+          When the mode is `stdout` and data is being read from files, all output is concatenated in a human-readable format.
 
           Possible values:
           - [96mfiles[0m:  format files in-place

--- a/front-end/tests/data/help/long_help_no_col.txt
+++ b/front-end/tests/data/help/long_help_no_col.txt
@@ -18,6 +18,8 @@ Options:
           The mode of operation
           
           The default is `files`, unless data is being read from stdin, in which case the default is `stdout`.
+          
+          When the mode is `stdout` and data is being read from files, all output is concatenated in a human-readable format.
 
           Possible values:
           - files:  format files in-place

--- a/orchestrator/src/command_line.rs
+++ b/orchestrator/src/command_line.rs
@@ -110,6 +110,9 @@ pub struct PasFmtConfiguration {
     ///
     /// The default is `files`, unless data is being read from stdin, in which
     /// case the default is `stdout`.
+    ///
+    /// When the mode is `stdout` and data is being read from files, all output
+    /// is concatenated in a human-readable format.
     #[arg(short, long, value_enum)]
     mode: Option<FormatMode>,
 


### PR DESCRIPTION
With Rust on Windows, only UTF-8 data can be written to stdout when it's
connected to a Console. This is because internally Rust wants to use the
`WriteConsoleW` function from the winapi, which of course accepts UTF-16
data only. Rust checks that your data is valid UTF-8 and converts it to
UTF-16.

It doesn't make sense to use the original encoding when outputing the
formatted data to a console because
1. It's only for human consumption; the most important thing is that it
   is rendered properly, and Unicode is the best way to do that.
2. The data goes through winapi and the terminal emulator which will
   choose their own representation for the data; we can't know what
   encoding is used for data copied to the clipboard from the terminal.
