### PR TITLE
Remove `Default` impl for FormattingSettings

### DIFF
--- a/front-end/benches/benchmark_submodules.rs
+++ b/front-end/benches/benchmark_submodules.rs
@@ -12,7 +12,7 @@ use walkdir::WalkDir;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use pasfmt::{format_with_settings, FormattingSettings};
+use pasfmt::format_with_settings;
 use pasfmt_orchestrator::predule::*;
 
 pasfmt_config!(Config);
@@ -26,7 +26,9 @@ fn bench_format_submodules(submodules: &[(&str, &PathBuf)], c: &mut Criterion) {
         group.bench_function(*name, |b| {
             b.iter(|| {
                 let config = Config::parse_from(["".into(), (*path).clone()]).config;
-                format_with_settings(FormattingSettings::default(), config, |e| panic!("{e:?}"));
+                format_with_settings(config.get_config_object().unwrap(), config, |e| {
+                    panic!("{e:?}")
+                });
             });
         });
     }

--- a/front-end/src/lib.rs
+++ b/front-end/src/lib.rs
@@ -48,15 +48,6 @@ pub struct FormattingSettings {
     encoding: &'static Encoding,
 }
 
-impl Default for FormattingSettings {
-    fn default() -> Self {
-        Self {
-            reconstruction: Default::default(),
-            encoding: default_encoding(),
-        }
-    }
-}
-
 impl TryFrom<Reconstruction> for ReconstructionSettings {
     type Error = InvalidReconstructionSettingsError;
 


### PR DESCRIPTION
It's not needed for anything now that the defaults are provided by the
deserialize impl. The only thing using it was the benchmark, but that
should have been getting the object via the CLI anyway.

Prompted by the change at https://github.com/integrated-application-development/pasfmt/pull/109/files#diff-d7c4083005a97fdf2b9ff93ca59f6011d7a0a24fabd6dd25c12381aff39cf426R57.
