### PR TITLE
Add test case for the 'dangling else'

### DIFF
--- a/core/datatests/generators/logical_line_parser.rs
+++ b/core/datatests/generators/logical_line_parser.rs
@@ -2286,6 +2286,15 @@ mod control_flows {
                     _|    Baz := Flarp;
                     _|end;
                 ",
+                inline_dangling_else = "
+                    _|begin
+                    _|  if True then
+                    _|    if True then
+                    _|      Foo := Bar;
+                    _|    else
+                    _|      Bar := Foo;
+                    _|end;
+                ",
                 compound = "
                     _|begin
                     _|  if True then begin


### PR DESCRIPTION
Delphi parses the 'dangling else' case by binding the `else` tightly to
the nearest `if`. I don't think we have any existing tests that ensure
that we parse it in a similar way.

See
- https://docwiki.embarcadero.com/RADStudio/en/Declarations_and_Statements_(Delphi)#If_Statements
- https://en.wikipedia.org/wiki/Dangling_else
