### PR TITLE
Fix lexing of asm blocks with conditional `asm` keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lexing of conditional directive expressions containing compiler directives, comments, or strings.
 - Lexing of compiler directives similar to conditional directives (e.g. `{$if_}`).
 - Lexing of unterminated asm text literals at EOF.
+- Lexing of sequential conditionally-compiled asm keywords.
 - `--config-file` no longer erroneously accepts a path to a directory and searches from it for a
   `pasfmt.toml` file. It is now an error to provide a path to a directory.
 - Detection of decoding errors when reading from stdin.


### PR DESCRIPTION
A semi-common practice in some libraries with inline assembly is
wrapping the `asm` keyword in conditional directives. This usually means
that there are multiple of the `asm` keyword before any of the inline
assembly code actually starts.

```delphi
{$if A}
asm // maybe some other stuff here
{$else}
asm
{$endif}
end
```

The problem with our existing implementation is that it disables the
identification of keywords when 'inside' asm blocks, but the notion of
'inside' isn't quite correct because we lex before 'preprocessing'
(whereas the Delphi language is designed to be processed in a single
pass).

As an aside, the reason we try to not identify keywords inside asm
blocks is to prevent instructions with the same name as keywords (shl,
shr, xor) as being lexed as keywords. None of the other reserved words
can actually be used in inline assembly, so this seemed OK.
