### PR TITLE
Set explicit encoding for Delphi submodules

### DIFF
--- a/front-end/benches/benchmark_submodules.rs
+++ b/front-end/benches/benchmark_submodules.rs
@@ -103,13 +103,12 @@ fn init_submodules() {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let source_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("benches");
-    set_current_dir(&source_dir)
-        .unwrap_or_else(|_| panic!("failed to change into the source directory: {source_dir:?}"));
+    let submodule_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("benches/modules");
+    set_current_dir(&submodule_dir).unwrap_or_else(|_| {
+        panic!("failed to change into the source directory: {submodule_dir:?}")
+    });
 
     init_submodules();
-
-    let submodule_dir = source_dir.join("modules");
 
     bench_format_submodules(
         &[

--- a/front-end/benches/modules/pasfmt.toml
+++ b/front-end/benches/modules/pasfmt.toml
@@ -1,0 +1,1 @@
+encoding = "windows-1252"


### PR DESCRIPTION
These Delphi libraries are encoded as ANSI. The exact codepage isn't so
important, but it's probably windows-1252.

In particular, making this change prevents the benchmarks from crashing
when run on Linux.
