### PR TITLE
Add web demo

### DIFF
--- a/.github/workflows/deploy-web-demo.yaml
+++ b/.github/workflows/deploy-web-demo.yaml
@@ -1,0 +1,75 @@
+name: Build and Deploy Web Demo to GitHub Pages
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+  # disabled until public
+  # push:
+  #   branches:
+  #     - master
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Rust
+        uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+
+      - uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: 'latest'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: |
+          cd web/demo
+          npm install
+
+      - name: Build with wasm-pack
+        run: |
+          cd web
+          wasm-pack build --target web
+
+      - name: Build with vite
+        run: |
+          cd web/demo
+          npx vite build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'web/demo/dist/'
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,23 +1249,24 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1274,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1284,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1297,9 +1298,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web"
+version = "0.0.0"
+dependencies = [
+ "pasfmt",
+ "pasfmt-core",
+ "toml",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,15 @@ members = [
     "orchestrator",
     "front-end",
     "core/datatests",
+    "web",
+]
+
+# exclude 'web' from default members
+default-members = [
+    "core",
+    "orchestrator",
+    "front-end",
+    "core/datatests",
 ]
 
 resolver = "2"

--- a/front-end/Cargo.toml
+++ b/front-end/Cargo.toml
@@ -27,6 +27,9 @@ assert_fs = { workspace = true }
 predicates = { workspace = true }
 glob = { workspace = true }
 
+[features]
+__demo = []
+
 [[bench]]
 name = "benchmark_submodules"
 harness = false

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "web"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2.100"
+pasfmt = { path = "../front-end", features = ["__demo"]}
+pasfmt-core = { path = "../core" }
+toml = { workspace = true }

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,44 @@
+# Web Demo
+
+This directory of the project contains a build of pasfmt for web assembly, paired with
+a web editor that runs it in a side-by-side view.
+
+## Build WASM
+
+### Prerequisites
+
+1. Rust (and cargo)
+2. [wasm-pack](https://github.com/rustwasm/wasm-pack):
+    ```sh
+    cargo install wasm-pack
+    ```
+
+### Build
+
+```sh
+cd web/
+wasm-pack build --target web
+```
+
+## Build Web UI
+
+### Prerequisites
+
+1. Node.js
+2. Dependencies
+    ```sh
+    cd web/demo
+    npm install
+    ```
+
+### Build
+
+```sh
+cd web/demo
+
+# for development
+npx vite
+
+# for production
+npx vite build
+```

--- a/web/demo/.gitignore
+++ b/web/demo/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/web/demo/index.html
+++ b/web/demo/index.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>pasfmt demo</title>
+    <style>
+      @media (prefers-color-scheme: light) {
+        :root {
+          color-scheme: light;
+        }
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          color-scheme: dark;
+        }
+      }
+      html,
+      body {
+        height: 100%;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
+        margin: 0;
+        border: 0;
+      }
+      .editor-container {
+        flex: 1;
+        /* without this, scrollbars appear when you shrink vertically */
+        min-height: 0;
+      }
+      .editor {
+        flex: 50%;
+        /* without this, scrollbars appear when you shrink vertically */
+        overflow: hidden;
+      }
+      #settings {
+        flex: 0 1 auto;
+      }
+      #editpane {
+        display: flex;
+        height: 100%;
+        flex-direction: row;
+      }
+      @media screen and (max-width: 120ch) {
+        #editpane {
+          flex-direction: column;
+        }
+        #formatted-editor {
+          border-top: solid rgba(0, 0, 0, 0.3);
+          border-width: 1px;
+        }
+      }
+      #diffpane {
+        height: 100%;
+      }
+
+      .modal {
+        display: none;
+        justify-content: center;
+        position: fixed;
+        z-index: 10;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.4);
+      }
+      :root {
+        --settings-border: currentColor;
+      }
+      .modal-content {
+        background-color: Canvas;
+        margin: auto;
+        padding: 20px;
+        border: 1px solid
+          color-mix(in srgb, var(--settings-border) 50%, transparent);
+        width: 400px;
+        border-radius: 10px;
+      }
+      .close {
+        float: right;
+      }
+      .modal form {
+        display: flex;
+        flex-direction: column;
+      }
+      .modal textarea {
+        resize: none;
+      }
+      #settingsEditor {
+        height: 300px;
+      }
+      .label {
+        margin: 10px 0 5px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="settingsModal" class="modal">
+      <div class="modal-content">
+        <button class="close" id="closeModal">Close</button>
+        <h2>Settings</h2>
+        <button id="resetToDefaultSettings">Reset to Default</button>
+        <div id="settingsEditor"></div>
+      </div>
+    </div>
+    <div id="settings">
+      <button id="openSettings">Open Settings</button>
+      <button id="toggle-view">Toggle Diff View</button>
+      <select name="sample file" id="sample-picker" class="app__sample">
+        <option value="" selected disabled hidden>Load Example</option>
+        <option value="/examples/simple.pas">simple</option>
+      </select>
+      <button id="share-example">Share Example</button>
+    </div>
+    <div class="editor-container" id="editorContainer">
+      <div class="" id="editpane">
+        <div class="editor" id="original-editor"></div>
+        <div class="editor" id="formatted-editor"></div>
+      </div>
+      <div class="" id="diffpane"></div>
+    </div>
+
+    <script type="module" src="/src/index.ts"></script>
+  </body>
+</html>

--- a/web/demo/package-lock.json
+++ b/web/demo/package-lock.json
@@ -1,0 +1,965 @@
+{
+  "name": "pasfmt-demo",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pasfmt-demo",
+      "version": "1.0.0",
+      "dependencies": {
+        "monaco-editor": "^0.52.0"
+      },
+      "devDependencies": {
+        "vite": "^6.0.7",
+        "vite-plugin-monaco-editor": "^1.1.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.31.0.tgz",
+      "integrity": "sha512-9NrR4033uCbUBRgvLcBrJofa2KY9DzxL2UKZ1/4xA/mnTNyhZCWBuD8X3tPm1n4KxcgaraOYgrFKSgwjASfmlA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.31.0.tgz",
+      "integrity": "sha512-iBbODqT86YBFHajxxF8ebj2hwKm1k8PTBQSojSt3d1FFt1gN+xf4CowE47iN0vOSdnd+5ierMHBbu/rHc7nq5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.31.0.tgz",
+      "integrity": "sha512-WHIZfXgVBX30SWuTMhlHPXTyN20AXrLH4TEeH/D0Bolvx9PjgZnn4H677PlSGvU6MKNsjCQJYczkpvBbrBnG6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.31.0.tgz",
+      "integrity": "sha512-hrWL7uQacTEF8gdrQAqcDy9xllQ0w0zuL1wk1HV8wKGSGbKPVjVUv/DEwT2+Asabf8Dh/As+IvfdU+H8hhzrQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.31.0.tgz",
+      "integrity": "sha512-S2oCsZ4hJviG1QjPY1h6sVJLBI6ekBeAEssYKad1soRFv3SocsQCzX6cwnk6fID6UQQACTjeIMB+hyYrFacRew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.31.0.tgz",
+      "integrity": "sha512-pCANqpynRS4Jirn4IKZH4tnm2+2CqCNLKD7gAdEjzdLGbH1iO0zouHz4mxqg0uEMpO030ejJ0aA6e1PJo2xrPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.31.0.tgz",
+      "integrity": "sha512-0O8ViX+QcBd3ZmGlcFTnYXZKGbFu09EhgD27tgTdGnkcYXLat4KIsBBQeKLR2xZDCXdIBAlWLkiXE1+rJpCxFw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.31.0.tgz",
+      "integrity": "sha512-w5IzG0wTVv7B0/SwDnMYmbr2uERQp999q8FMkKG1I+j8hpPX2BYFjWe69xbhbP6J9h2gId/7ogesl9hwblFwwg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.31.0.tgz",
+      "integrity": "sha512-JyFFshbN5xwy6fulZ8B/8qOqENRmDdEkcIMF0Zz+RsfamEW+Zabl5jAb0IozP/8UKnJ7g2FtZZPEUIAlUSX8cA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.31.0.tgz",
+      "integrity": "sha512-kpQXQ0UPFeMPmPYksiBL9WS/BDiQEjRGMfklVIsA0Sng347H8W2iexch+IEwaR7OVSKtr2ZFxggt11zVIlZ25g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.31.0.tgz",
+      "integrity": "sha512-pMlxLjt60iQTzt9iBb3jZphFIl55a70wexvo8p+vVFK+7ifTRookdoXX3bOsRdmfD+OKnMozKO6XM4zR0sHRrQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.31.0.tgz",
+      "integrity": "sha512-D7TXT7I/uKEuWiRkEFbed1UUYZwcJDU4vZQdPTcepK7ecPhzKOYk4Er2YR4uHKme4qDeIh6N3XrLfpuM7vzRWQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.31.0.tgz",
+      "integrity": "sha512-wal2Tc8O5lMBtoePLBYRKj2CImUCJ4UNGJlLwspx7QApYny7K1cUYlzQ/4IGQBLmm+y0RS7dwc3TDO/pmcneTw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.31.0.tgz",
+      "integrity": "sha512-O1o5EUI0+RRMkK9wiTVpk2tyzXdXefHtRTIjBbmFREmNMy7pFeYXCFGbhKFwISA3UOExlo5GGUuuj3oMKdK6JQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.31.0.tgz",
+      "integrity": "sha512-zSoHl356vKnNxwOWnLd60ixHNPRBglxpv2g7q0Cd3Pmr561gf0HiAcUBRL3S1vPqRC17Zo2CX/9cPkqTIiai1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.31.0.tgz",
+      "integrity": "sha512-ypB/HMtcSGhKUQNiFwqgdclWNRrAYDH8iMYH4etw/ZlGwiTVxBz2tDrGRrPlfZu6QjXwtd+C3Zib5pFqID97ZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.31.0.tgz",
+      "integrity": "sha512-JuhN2xdI/m8Hr+aVO3vspO7OQfUFO6bKLIRTAy0U15vmWjnZDLrEgCZ2s6+scAYaQVpYSh9tZtRijApw9IXyMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.31.0.tgz",
+      "integrity": "sha512-U1xZZXYkvdf5MIWmftU8wrM5PPXzyaY1nGCI4KI4BFfoZxHamsIe+BtnPLIvvPykvQWlVbqUXdLa4aJUuilwLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.31.0.tgz",
+      "integrity": "sha512-ul8rnCsUumNln5YWwz0ted2ZHFhzhRRnkpBZ+YRuHoRAlUji9KChpOUOndY7uykrPEPXVbHLlsdo6v5yXo/TXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://nexus.om.net/repository/npm-public/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://nexus.om.net/repository/npm-public/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://nexus.om.net/repository/npm-public/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.8",
+      "resolved": "https://nexus.om.net/repository/npm-public/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://nexus.om.net/repository/npm-public/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.1",
+      "resolved": "https://nexus.om.net/repository/npm-public/postcss/-/postcss-8.5.1.tgz",
+      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.8",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.31.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/rollup/-/rollup-4.31.0.tgz",
+      "integrity": "sha512-9cCE8P4rZLx9+PjoyqHLs31V9a9Vpvfo4qNcs6JCiGWYhw2gijSetFbH6SSy1whnkgcefnUwr8sad7tgqsGvnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.6"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.31.0",
+        "@rollup/rollup-android-arm64": "4.31.0",
+        "@rollup/rollup-darwin-arm64": "4.31.0",
+        "@rollup/rollup-darwin-x64": "4.31.0",
+        "@rollup/rollup-freebsd-arm64": "4.31.0",
+        "@rollup/rollup-freebsd-x64": "4.31.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.31.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.31.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.31.0",
+        "@rollup/rollup-linux-arm64-musl": "4.31.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.31.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.31.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.31.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.31.0",
+        "@rollup/rollup-linux-x64-gnu": "4.31.0",
+        "@rollup/rollup-linux-x64-musl": "4.31.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.31.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.31.0",
+        "@rollup/rollup-win32-x64-msvc": "4.31.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://nexus.om.net/repository/npm-public/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.0.7",
+      "resolved": "https://nexus.om.net/repository/npm-public/vite/-/vite-6.0.7.tgz",
+      "integrity": "sha512-RDt8r/7qx9940f8FcOIAH9PTViRrghKaK2K1jY3RaAURrEUbm9Du1mJ72G+jlhtG3WwodnfzY8ORQZbBavZEAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.24.2",
+        "postcss": "^8.4.49",
+        "rollup": "^4.23.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-monaco-editor": {
+      "version": "1.1.0",
+      "resolved": "https://nexus.om.net/repository/npm-public/vite-plugin-monaco-editor/-/vite-plugin-monaco-editor-1.1.0.tgz",
+      "integrity": "sha512-IvtUqZotrRoVqwT0PBBDIZPNraya3BxN/bfcNfnxZ5rkJiGcNtO5eAOWWSgT7zullIAEqQwxMU83yL9J5k7gww==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "monaco-editor": ">=0.33.0"
+      }
+    }
+  }
+}

--- a/web/demo/package.json
+++ b/web/demo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "pasfmt-demo",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "monaco-editor": "^0.52.0"
+  },
+  "devDependencies": {
+    "vite": "^6.0.7",
+    "vite-plugin-monaco-editor": "^1.1.0"
+  }
+}

--- a/web/demo/public/examples/simple.pas
+++ b/web/demo/public/examples/simple.pas
@@ -1,0 +1,52 @@
+uses System.SysUtils;
+
+const A = 0;
+
+procedure Foo; begin Bar('', 0); end;
+
+type A = (
+aa, ab, 
+
+accc);
+
+type A = ( // force break
+aa, ab
+);
+
+type TRec = record A: string[255]; B: array[0
+..1] of record AA: Integer; BB: Double    ; end; end;
+
+const Rec: TRec = (A: '';
+  B: ((AA: 0; // force break
+   BB: 1.0), (AA: 0; BB: 1.0)));
+
+const Precedence = Length([// force break
+0,1,2,3 * 2])
+ + High(Integer) shr 2 + 1 *
+ Low(Integer);
+
+
+const Precedence2 = Length([// force break
+0,1,2,3 * 2] + [10]);
+
+procedure ForwardedDecl; forward;
+// Not a nested procedure, because the last decl was forwarded.
+procedure CallProc(I: Integer; P: TProc<Integer>); begin P(I); end;
+
+procedure AnonymousRoutines;
+procedure NestedProc; begin end;
+var A: TProc<Integer>;
+begin
+  A := procedure(I: Integer) begin Inc(I); end;
+  A := procedure(I: Integer)
+  begin  // force break
+Inc(I); end;
+
+  // nested
+  A := procedure(I: Integer)
+  begin 
+    Inc(I); 
+    CallProc(1, procedure(I: Integer) // force break
+    begin if True then Inc(I); end);
+  end;
+end;

--- a/web/demo/src/delphi.ts
+++ b/web/demo/src/delphi.ts
@@ -1,0 +1,86 @@
+/*
+Extends the provided pascal language definition.
+  * add support for the alternative multiline command syntax: `(* *)`
+  * add support for hex integer literals of more lengths
+  * add support for underscores in hex integer literals
+  * add support for binary integer literals
+  * add support for hex and binary character literals
+  * remove | and % from operators
+  * remove treatment of < and > as matched brackets (it's not always generics)
+*/
+
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
+import * as pascal from "monaco-editor/esm/vs/basic-languages/pascal/pascal";
+
+monaco.languages.register({ id: "delphi" });
+
+const lang: monaco.languages.IMonarchLanguage = structuredClone(pascal.language);
+
+// alt comments
+lang.tokenizer.altcomment = [
+  [/[^)*]+/, "comment"],
+  [/\*\)/, "comment", "@pop"],
+  [/[)*]/, "comment"],
+];
+lang.tokenizer.whitespace.push([/\(\*/, "comment", "@altcomment"]);
+
+// all of these use unshift to have higher precedence that the existing rules
+
+// binary integer literals
+lang.tokenizer.root.unshift([/%[01_]*/, "number.hex"]);
+// more general hex integer
+lang.tokenizer.root.unshift([/\$[0-9a-fA-F_]*/, "number.hex"]);
+// more general hex character literals
+lang.tokenizer.root.unshift([/#\$[0-9a-fA-F_]*/, "string"]);
+// binary character literals
+lang.tokenizer.root.unshift([/#%[01_]*/, "string"]);
+
+// removed | %
+lang.symbols = /[=><:@^&+\-*\/]+/;
+
+lang.operators.splice(lang.operators.indexOf("%"), 1);
+
+// <> are configured to be matched, as generics.
+// This completely overlooks the match that much of the time it's actually
+// just a binary operator. It takes a lot of work to undo this mistake.
+
+lang.brackets = [
+  // used for comments
+  // { open: "{", close: "}", token: "delimiter.curly" },
+  { open: "[", close: "]", token: "delimiter.square" },
+  { open: "(", close: ")", token: "delimiter.parenthesis" },
+  // { open: "<", close: ">", token: "delimiter.angle" },
+];
+
+let toRemove = lang.tokenizer.root.findIndex(
+  (elm) =>
+    Array.isArray(elm) && elm[0].toString() == /[<>](?!@symbols)/.toString()
+);
+lang.tokenizer.root.splice(toRemove, 1);
+
+const conf = structuredClone(pascal.conf);
+
+conf.autoClosingPairs = [
+  { open: "{", close: "}" },
+  { open: "[", close: "]" },
+  { open: "(", close: ")" },
+  // { open: "<", close: ">" },
+  { open: "'", close: "'" },
+];
+
+conf.surroundingPairs = [
+  { open: "{", close: "}" },
+  { open: "[", close: "]" },
+  { open: "(", close: ")" },
+  // { open: "<", close: ">" },
+  { open: "'", close: "'" },
+];
+
+conf.brackets = [
+  ["{", "}"],
+  ["[", "]"],
+  ["(", ")"],
+  // ["<", ">"]
+];
+
+export { lang, conf };

--- a/web/demo/src/index.ts
+++ b/web/demo/src/index.ts
@@ -1,0 +1,274 @@
+import init, { fmt, default_settings_toml, SettingsWrapper } from "../../pkg";
+
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
+
+// support for ini, good enough for our TOML config
+import "monaco-editor/esm/vs/basic-languages/ini/ini.contribution";
+
+// extra editor features
+// a subset of the imports from 'monaco-editor/esm/vs/editor/editor.all.js'
+import "monaco-editor/esm/vs/editor/contrib/readOnlyMessage/browser/contribution.js";
+import "monaco-editor/esm/vs/editor/browser/widget/diffEditor/diffEditor.contribution.js";
+import "monaco-editor/esm/vs/editor/contrib/diffEditorBreadcrumbs/browser/contribution.js";
+import "monaco-editor/esm/vs/editor/contrib/find/browser/findController.js";
+import "monaco-editor/esm/vs/editor/contrib/folding/browser/folding.js";
+import "monaco-editor/esm/vs/editor/contrib/fontZoom/browser/fontZoom.js";
+import "monaco-editor/esm/vs/editor/contrib/inlineEdit/browser/inlineEdit.contribution.js";
+import "monaco-editor/esm/vs/editor/contrib/inlineEdits/browser/inlineEdits.contribution.js";
+import "monaco-editor/esm/vs/editor/contrib/hover/browser/hoverContribution.js";
+import "monaco-editor/esm/vs/editor/contrib/wordOperations/browser/wordOperations.js";
+
+// custom delphi tokenizer
+import * as delphi from "./delphi";
+
+await init();
+
+const diffEditorContainer = document.getElementById("diffpane")!;
+const sideBySideContainer = document.getElementById("editpane")!;
+
+monaco.languages.setMonarchTokensProvider("delphi", delphi.lang);
+monaco.languages.setLanguageConfiguration("delphi", delphi.conf);
+
+const originalModel = monaco.editor.createModel("", "delphi");
+const formattedModel = monaco.editor.createModel("", "delphi");
+
+const makeRuler = (col: number): monaco.editor.IRulerOption => ({
+  column: col,
+  color: null,
+});
+
+// It's actually TOML, but ini is close enough.
+// A PR is open to add TOML support https://github.com/microsoft/monaco-editor/pull/4786.
+const settingsModel = monaco.editor.createModel("", "ini");
+const settingsDiv = document.getElementById("settingsEditor")!;
+const settingsEditor = monaco.editor.create(settingsDiv, {
+  model: settingsModel,
+  automaticLayout: true,
+  readOnly: false,
+  minimap: { enabled: false },
+  scrollbar: { vertical: "hidden", horizontal: "hidden" },
+});
+
+const resetDefaultSettingsButton = document.getElementById(
+  "resetToDefaultSettings"
+)!;
+const resetSettings = () => settingsEditor.setValue(default_settings_toml());
+resetSettings();
+resetDefaultSettingsButton.onclick = resetSettings;
+
+const parseSettings = () => {
+  try {
+    return new SettingsWrapper(settingsEditor.getValue());
+  } catch (error) {
+    throw new Error("Failed to parse settings", {
+      cause: error,
+    });
+  }
+};
+
+const closeModalButton = document.getElementById(
+  "closeModal"
+) as HTMLButtonElement;
+
+const setSettingsBorderCol = (col) =>
+  document.documentElement.style.setProperty("--settings-border", col);
+
+let settingsErrorTimeout;
+let settingsValid = true;
+settingsModel.onDidChangeContent(() => {
+  clearTimeout(settingsErrorTimeout);
+
+  try {
+    parseSettings();
+
+    settingsValid = true;
+    closeModalButton.disabled = false;
+    setSettingsBorderCol("currentColor");
+    clearErrorsInModel(settingsModel);
+  } catch (error) {
+    settingsValid = false;
+    closeModalButton.disabled = true;
+    settingsErrorTimeout = setTimeout(() => {
+      setSettingsBorderCol("red");
+      renderErrorInModel(error, settingsModel);
+    }, 200);
+  }
+});
+
+const modal = document.getElementById("settingsModal")!;
+const openSettingsButton = document.getElementById("openSettings")!;
+
+// Open the modal
+openSettingsButton.onclick = () => (modal.style.display = "flex");
+
+const closeSettings = () => {
+  modal.style.display = "none";
+  formatEditors();
+};
+
+const closeSettingsIfValid = () => {
+  if (settingsValid) closeSettings();
+};
+
+closeModalButton.onclick = closeSettingsIfValid;
+
+window.addEventListener("click", (event) => {
+  if (event.target == modal) {
+    closeSettingsIfValid();
+  }
+});
+
+const originalEditorDiv = document.getElementById("original-editor")!;
+const formattedEditorDiv = document.getElementById("formatted-editor")!;
+
+const originalEditor = monaco.editor.create(originalEditorDiv, {
+  model: originalModel,
+  automaticLayout: true,
+  readOnly: false,
+});
+
+const formattedEditor = monaco.editor.create(formattedEditorDiv, {
+  model: formattedModel,
+  automaticLayout: true,
+  readOnly: true,
+  renderValidationDecorations: "on",
+});
+
+const createDiffEditor = (): monaco.editor.IStandaloneDiffEditor => {
+  let diffEditor = monaco.editor.createDiffEditor(diffEditorContainer, {
+    automaticLayout: true,
+    originalEditable: true,
+    readOnly: true,
+    ignoreTrimWhitespace: false,
+  });
+  diffEditor.setModel({
+    original: originalModel,
+    modified: formattedModel,
+  });
+  return diffEditor;
+};
+
+// Start with the diff editor loaded
+var diffEditor = createDiffEditor();
+let isDiffView = true;
+
+const renderEditors = () => {
+  if (isDiffView) {
+    sideBySideContainer.style.display = "none";
+    diffEditorContainer.style.display = "block";
+    diffEditor.layout();
+  } else {
+    diffEditorContainer.style.display = "none";
+    sideBySideContainer.style.display = "flex";
+    originalEditor.layout();
+    formattedEditor.layout();
+  }
+};
+renderEditors();
+
+const toggleDiffView = () => {
+  isDiffView = !isDiffView;
+  renderEditors();
+};
+
+document
+  .getElementById("toggle-view")!
+  .addEventListener("click", toggleDiffView);
+
+const renderErrorInModel = (error, model) => {
+  const errorMessage =
+    error + (error.cause ? `\nCaused by: ${error.cause}` : "");
+  const markers = [
+    {
+      startLineNumber: 1,
+      startColumn: 1,
+      endLineNumber: model.getLineCount(),
+      endColumn: 1,
+      message: errorMessage,
+      severity: monaco.MarkerSeverity.Error,
+    },
+  ];
+
+  monaco.editor.setModelMarkers(model, "", markers);
+};
+
+const clearErrorsInModel = (model) => {
+  monaco.editor.setModelMarkers(model, "", []);
+};
+
+const updateRulers = (maxLineLen) => {
+  originalEditor.updateOptions({ rulers: [makeRuler(maxLineLen)] });
+  formattedEditor.updateOptions({ rulers: [makeRuler(maxLineLen)] });
+  if (diffEditor !== undefined) {
+    diffEditor.updateOptions({ rulers: [makeRuler(maxLineLen)] });
+  }
+};
+
+const formatEditors = () => {
+  try {
+    let settingsObj = parseSettings();
+    updateRulers(settingsObj.max_line_len());
+    formattedModel.setValue(fmt(originalModel.getValue(), settingsObj));
+  } catch (error) {
+    console.log(error);
+    renderErrorInModel(error, formattedModel);
+  }
+};
+originalModel.onDidChangeContent(formatEditors);
+
+const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
+const updateTheme = () => {
+  monaco.editor.setTheme(prefersDark.matches ? "vs-dark" : "vs");
+};
+updateTheme();
+prefersDark.onchange = updateTheme;
+
+const samplePicker = document.getElementById(
+  "sample-picker"
+) as HTMLSelectElement;
+
+const loadSampleFile = async (sampleFile: string) => {
+  originalModel.setValue(await fetch(sampleFile).then((resp) => resp.text()));
+};
+
+const loadSample = async () => {
+  var sampleFile = samplePicker.value;
+  samplePicker.value = "";
+  if (sampleFile) {
+    loadSampleFile(sampleFile);
+  } else {
+    originalModel.setValue("");
+  }
+  formatEditors();
+};
+document
+  .getElementById("sample-picker")!
+  .addEventListener("change", loadSample);
+
+const url = new URL(window.location.href);
+let source = url.searchParams.get("source");
+let settings = url.searchParams.get("settings");
+
+if (source !== null) {
+  let decoded = atob(source);
+  originalEditor.setValue(decoded);
+} else {
+  loadSampleFile("/examples/simple.pas");
+}
+
+if (settings !== null) {
+  let decoded = atob(settings);
+  settingsEditor.setValue(decoded);
+}
+
+const shareExample = document.getElementById(
+  "share-example"
+) as HTMLButtonElement;
+shareExample.onclick = () => {
+  url.searchParams.set("source", btoa(originalEditor.getValue()));
+  url.searchParams.set("settings", btoa(settingsEditor.getValue()));
+  window.history.replaceState(null, "", url);
+  navigator.clipboard.writeText(window.location.href);
+};
+
+formatEditors();

--- a/web/demo/vite.config.mts
+++ b/web/demo/vite.config.mts
@@ -1,0 +1,22 @@
+import { defineConfig, PluginOption } from "vite";
+
+// There's some issue with ES modules and this dependency.
+// Without this hack, there is an error 'monacoEditorPlugin is not a function'.
+import _monacoEditorPlugin from "vite-plugin-monaco-editor";
+const monacoEditorPlugin =
+  (_monacoEditorPlugin as any).default || _monacoEditorPlugin;
+
+export default defineConfig({
+  plugins: [monacoEditorPlugin({ languageWorkers: ["editorWorkerService"] })],
+  build: {
+    // for top-level await
+    target: "esnext",
+  },
+  // configure the dev server
+  server: {
+    fs: {
+      // the wasm files are up one level
+      allow: [".."],
+    },
+  },
+});

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1,0 +1,35 @@
+use pasfmt::{make_formatter, FormattingSettings};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct SettingsWrapper {
+    formatting_settings: FormattingSettings,
+}
+
+#[wasm_bindgen]
+impl SettingsWrapper {
+    #[wasm_bindgen(constructor)]
+    pub fn new(settings: String) -> Result<Self, String> {
+        let formatting_settings = toml::from_str(&settings).map_err(|e| e.to_string())?;
+        Ok(SettingsWrapper {
+            formatting_settings,
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn max_line_len(&self) -> u32 {
+        self.formatting_settings.max_line_length()
+    }
+}
+
+#[wasm_bindgen]
+pub fn default_settings_toml() -> String {
+    toml::to_string_pretty(&FormattingSettings::default()).unwrap()
+}
+
+#[wasm_bindgen]
+pub fn fmt(src: &str, settings: &SettingsWrapper) -> Result<String, String> {
+    let formatter = make_formatter(&settings.formatting_settings).map_err(|e| e.to_string())?;
+
+    Ok(formatter.format(src))
+}


### PR DESCRIPTION
With #109 merged, we can show off what this formatter can do with a little web demo!

Here's an overview of the tooling used
1. [`wasm-bindgen`](https://github.com/rustwasm/wasm-bindgen) generates all glue code between the JS and the rust code as WASM
2. [`wasm-pack`](https://github.com/rustwasm/wasm-pack) builds and packages the rust library for WASM
3. [monaco-editor](https://github.com/microsoft/monaco-editor) provides the web editor, with a vscode-like experience and a fantastic diff editor
4. [`vite`](https://vite.dev/) does the bundling and minifying (and is great for development)

The idea (when the project is public) is to publish this demo via GitHub Pages. I've included a GitHub Actions workflow to build and publish the site, but have disabled its triggers.

It looks like this
![image](https://github.com/user-attachments/assets/2bc88fd4-d550-4ab1-8308-609c0386155f)