### PR TITLE
Space out enum configuration options in help message

### DIFF
--- a/front-end/src/lib.rs
+++ b/front-end/src/lib.rs
@@ -207,7 +207,7 @@ Places the `begin` after control flow statements (e.g. `if`).
 If \"always_wrap\", the `begin` will always be placed on the next line
 at the same indentation as the statement it is within.\
                     ",
-                hint: "[auto|always_wrap]",
+                hint: "[ auto | always_wrap ]",
                 default: format!("{:?}", defaults.begin_style).to_lowercase(),
             },
             ConfigItem {
@@ -253,7 +253,7 @@ If \"native\":
   * on Windows, \"crlf\" is used
   * otherwise, \"lf\" is used\
                     ",
-                hint: "[lf|crlf|native]",
+                hint: "[ lf | crlf | native ]",
                 default: format!("{:?}", defaults.line_ending).to_lowercase(),
             },
         ]

--- a/front-end/tests/data/help/config_help_col.txt
+++ b/front-end/tests/data/help/config_help_col.txt
@@ -3,7 +3,7 @@ Available configuration options:
 [36mwrap_column[0m [3m<unsigned integer>[0m (default: [33m120[0m)
   Target line length before wrapping
 
-[36mbegin_style[0m [3m[auto|always_wrap][0m (default: [33mauto[0m)
+[36mbegin_style[0m [3m[ auto | always_wrap ][0m (default: [33mauto[0m)
   Places the `begin` after control flow statements (e.g. `if`).
   If "always_wrap", the `begin` will always be placed on the next line
   at the same indentation as the statement it is within.
@@ -27,7 +27,7 @@ Available configuration options:
   Continuations are used to further indent the wrapped lines from a "logical line".
   Indentations are used to indent the base of a "logical line".
 
-[36mline_ending[0m [3m[lf|crlf|native][0m (default: [33mnative[0m)
+[36mline_ending[0m [3m[ lf | crlf | native ][0m (default: [33mnative[0m)
   Line ending character sequence.
   If "native":
     * on Windows, "crlf" is used

--- a/front-end/tests/data/help/config_help_no_col.txt
+++ b/front-end/tests/data/help/config_help_no_col.txt
@@ -3,7 +3,7 @@ Available configuration options:
 wrap_column <unsigned integer> (default: 120)
   Target line length before wrapping
 
-begin_style [auto|always_wrap] (default: auto)
+begin_style [ auto | always_wrap ] (default: auto)
   Places the `begin` after control flow statements (e.g. `if`).
   If "always_wrap", the `begin` will always be placed on the next line
   at the same indentation as the statement it is within.
@@ -27,7 +27,7 @@ continuation_indents <unsigned integer> (default: 2)
   Continuations are used to further indent the wrapped lines from a "logical line".
   Indentations are used to indent the base of a "logical line".
 
-line_ending [lf|crlf|native] (default: native)
+line_ending [ lf | crlf | native ] (default: native)
   Line ending character sequence.
   If "native":
     * on Windows, "crlf" is used


### PR DESCRIPTION
It was a bit too dense for my liking.
