### PR TITLE
Optimise get_specific_context_stack using binary search

### DIFF
--- a/core/src/rules/optimising_line_formatter/contexts.rs
+++ b/core/src/rules/optimising_line_formatter/contexts.rs
@@ -1189,10 +1189,11 @@ impl<'a> LineFormattingContexts<'a> {
             formatting_contexts: self,
             stack: self
                 .update_indices
-                .iter()
-                .rev()
-                .find(|&&(context_token_index, _)| context_token_index <= line_index)
-                .map(|(_, indices)| indices),
+                .partition_point(|&(context_token_index, _)| context_token_index <= line_index)
+                // partition_point returns the index of the first element that doesn't satisfy the predicate, but
+                // we want the last element that does
+                .checked_sub(1)
+                .map(|idx| &self.update_indices[idx].1),
         }
     }
 }


### PR DESCRIPTION
For some codebases, the loop from get_specific_context_stack ends up
being the hottest code of all. It's easy to see how this could be the
case; the inner loop searches from the end of the slice for an element
that matches the predicate, and the outer loop (the 'indiff loop) shifts
the element to search for usually by one every iteration. So what we
have is a quadratic complexity loop.

Fortunately the `update_indices` field is sorted by construction, so we
can do a binary search to find the right position.

We hadn't noticed this issue because for most codebases it doesn't seem
to matter that this loop is inefficient, presumably because the logical
lines are short enough (in tokens). However, in the case of
DelphiEncryptionCompendium (in our benchmarks) this change reduces
runtime by almost 75%.
