### PR TITLE
Add link to releases in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
 
 ## Getting Started
 
+Download the [latest release](https://github.com/integrated-application-development/pasfmt/releases/latest)
+or [build from source](#building-from-source).
+
 To format one `pas`, `dpr`, or `dpk` file (in-place), run
 
 ```sh


### PR DESCRIPTION
For users that aren't familiar with the typical GitHub release process,
this will make the downloads easier to locate.
