### PR TITLE
Switch to dtolnay/rust-toolchain to the web demo workflow

### DIFF
--- a/.github/workflows/deploy-web-demo.yaml
+++ b/.github/workflows/deploy-web-demo.yaml
@@ -28,10 +28,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Set up Rust
-        uses: actions/setup-rust@v1
-        with:
-          rust-version: stable
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
 
       - uses: jetli/wasm-pack-action@v0.4.0
         with:


### PR DESCRIPTION
By mistake I used a different action than the other workflows to install
rust.
