### PR TITLE
Fix base URL in vite config

### DIFF
--- a/web/demo/vite.config.mts
+++ b/web/demo/vite.config.mts
@@ -19,5 +19,5 @@ export default defineConfig({
       allow: [".."],
     },
   },
-  base: "https://integrated-application-development.github.io/pasfmt/",
+  base: "/pasfmt/",
 });


### PR DESCRIPTION
That comment I linked to in #155 was apparently wrong.

The [vite documentation](https://vite.dev/guide/static-deploy.html#github-pages) says

> If you are deploying to https://\<USERNAME\>.github.io/\<REPO\>/ (eg. your
> repository is at https://github.com/<USERNAME\>/\<REPO\>), then set base to
> '/\<REPO\>/'.
