### PR TITLE
Fix web-demo tokenizer for multiline strings

### DIFF
--- a/web/demo/public/examples/simple.pas
+++ b/web/demo/public/examples/simple.pas
@@ -50,3 +50,11 @@ Inc(I); end;
     begin if True then Inc(I); end);
   end;
 end;
+
+const S1 = '''
+multiline string
+''';
+
+const S2 = '''''
+'''
+''''';

--- a/web/demo/src/delphi.ts
+++ b/web/demo/src/delphi.ts
@@ -5,6 +5,7 @@ Extends the provided pascal language definition.
   * add support for underscores in hex integer literals
   * add support for binary integer literals
   * add support for hex and binary character literals
+  * add support for multiline strings
   * remove | and % from operators
   * remove treatment of < and > as matched brackets (it's not always generics)
 */
@@ -14,7 +15,11 @@ import * as pascal from "monaco-editor/esm/vs/basic-languages/pascal/pascal";
 
 monaco.languages.register({ id: "delphi" });
 
-const lang: monaco.languages.IMonarchLanguage = structuredClone(pascal.language);
+const lang: monaco.languages.IMonarchLanguage = structuredClone(
+  pascal.language
+);
+
+lang.includeLF = true;
 
 // alt comments
 lang.tokenizer.altcomment = [
@@ -34,6 +39,24 @@ lang.tokenizer.root.unshift([/\$[0-9a-fA-F_]*/, "number.hex"]);
 lang.tokenizer.root.unshift([/#\$[0-9a-fA-F_]*/, "string"]);
 // binary character literals
 lang.tokenizer.root.unshift([/#%[01_]*/, "string"]);
+
+// multiline strings
+lang.tokenizer.root.unshift([
+  /('(?:'')+)\r?\n/,
+  { token: "string", next: "@multilinestring.$1" },
+]);
+lang.tokenizer.multilinestring = [
+  [
+    /('(?:'')+)/,
+    {
+      cases: {
+        "$1==$S2": { token: "string", next: "@pop" },
+        "@default": "string",
+      },
+    },
+  ],
+  [/./, "string"],
+];
 
 // removed | %
 lang.symbols = /[=><:@^&+\-*\/]+/;


### PR DESCRIPTION
At first I just wanted to add the regex pattern `('(?:'')+)\r?\n.*?\1`
but this doesn't work with Monarch.

This approach is pretty complex, but it's the most correct and works
with the tools provided by Monarch.

See
- https://github.com/microsoft/monaco-editor/issues/1512
- https://microsoft.github.io/monaco-editor/monarch-static.html#htmlembed
