### PR TITLE
Add documentation for the configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ pasfmt --help
 
 Some aspects of formatting style can be controlled from a configuration file.
 
+The full list of available options is [here](./docs/CONFIGURATION.md), and can also be printed from the command line by running `pasfmt -C help`.
+
 To customise the configuration, create a file called `pasfmt.toml` in the root directory of the project
 you are formatting. Make sure that `pasfmt` is being run from that directory, or a child directory.
 
@@ -64,13 +66,6 @@ Specific `pasfmt.toml` files can also be used from the command-line:
 ```sh
 pasfmt --config-file path/to/pasfmt.toml path/to/file.pas
 ```
-
-> [!TIP]
-> For a full list of available configuration options, run
->
-> ```sh
-> pasfmt -C help
-> ```
 
 Additionally, configuration options can be specified on the command-line, which will override values from the file:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,87 @@
+# Configuration
+
+Some aspects of formatting style are configurable.
+
+Configuration options can either be specified in a `pasfmt.toml` configuration file, or on the command line.
+
+## Available Options
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Valid Values</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>wrap_column</td>
+      <td>&lt;unsigned&nbsp;integer&gt;</td>
+      <td>120</td>
+      <td>Target line length before wrapping</td>
+    </tr>
+    <tr>
+      <td>begin_style</td>
+      <td>"auto", "always_wrap"</td>
+      <td>"auto"</td>
+      <td>
+        Places the <code>begin</code> after control flow statements (e.g. <code>if</code>).<br>
+        If "always_wrap", the <code>begin</code> will always be placed on the next line at the
+        same indentation as the statement it is within.
+      </td>
+    </tr>
+    <tr>
+      <td>encoding</td>
+      <td>"native", &lt;NAME&gt;</td>
+      <td>"native"</td>
+      <td>
+        The encoding to use when reading and writing files.<br />
+        If "native":
+        <ul>
+          <li>on Windows, the system ANSI codepage is used</li>
+          <li>
+            otherwise, UTF-8 is used In all cases a detected BOM will override
+            the configured encoding.
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>use_tabs</td>
+      <td>&lt;boolean&gt;</td>
+      <td>false</td>
+      <td>Use tab characters for indentation</td>
+    </tr>
+    <tr>
+      <td>tab_width</td>
+      <td>&lt;unsigned&nbsp;integer&gt;</td>
+      <td>2</td>
+      <td>Number of spaces per indentation (ignored if use_tabs=true)</td>
+    </tr>
+    <tr>
+      <td>continuation_indents</td>
+      <td>&lt;unsigned&nbsp;integer&gt;</td>
+      <td>2</td>
+      <td>
+        Width of continuations, measured as a multiple of the configured
+        indentation. Continuations are used to further indent the wrapped lines
+        from a "logical line". Indentations are used to indent the base of a
+        "logical line".
+      </td>
+    </tr>
+    <tr>
+      <td>line_ending</td>
+      <td>"lf", "crlf", "native"</td>
+      <td>"native"</td>
+      <td>
+        Line ending character sequence.<br />
+        If "native":
+        <ul>
+          <li>on Windows, "crlf" is used</li>
+          <li>otherwise, "lf" is used</li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
Initially I thought it would be enough to have the CLI spit out the
available options, but I realise now that it may be a key factor for a
user in deciding whether to download and run the tool at all.

It would be nice to have this generated to avoid the duplication, but
for now it's best to just quickly get some docs out.
