### PR TITLE
Fix line comment tokenizing in web demo

### DIFF
--- a/web/demo/src/delphi.ts
+++ b/web/demo/src/delphi.ts
@@ -27,7 +27,16 @@ lang.tokenizer.altcomment = [
   [/\*\)/, "comment", "@pop"],
   [/[)*]/, "comment"],
 ];
-lang.tokenizer.whitespace.push([/\(\*/, "comment", "@altcomment"]);
+
+lang.tokenizer.whitespace = [
+  [/[ \t\r\n]+/, "white"],
+  [/\{/, "comment", "@comment"],
+  // the trailing $ is incompatible with the includeLF=true setting
+  // [/\/\/.*$/, "comment"],
+  [/\/\/.*/, "comment"],
+  // add support for alt comments
+  [/\(\*/, "comment", "@altcomment"],
+];
 
 // all of these use unshift to have higher precedence that the existing rules
 


### PR DESCRIPTION
The fix for multiline strings actually broke single line comments.

The problem is that setting the includeLF property to true means that the trailing `$` in the existing pattern no longer matched, because the trailing `\n` character hadn't been matched by the dot.