### PR TITLE
Switch to sccache for CI caching of builds

### DIFF
--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -10,16 +10,13 @@ runs:
       with:
         components: rustfmt, clippy
 
-    - name: Cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: rust-toolchain-${{ steps.toolchain.outputs.cachekey }}-cargo-${{ hashFiles('**/Cargo.lock') }}-job-${{ github.job }}
-        restore-keys: |
-          rust-toolchain-${{ steps.toolchain.outputs.cachekey }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          rust-toolchain-${{ steps.toolchain.outputs.cachekey }}
-          rust-
+    - name: Run sccache-cache only on non-release runs
+      if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+      uses: mozilla-actions/sccache-action@v0.0.7
 
+    - name: Set Rust caching env vars only on non-release runs
+      if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+      shell: bash
+      run: |
+        echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV


### PR DESCRIPTION
The current approach of caching the entire runner has been feeling a bit
slow and inefficient for a while now.

`sccache` is a generic compiler wrapper from Mozilla that caches
compilation artifacts, and it has a simple integration with GitHub
actions. I figure it's worth a shot.
