### PR TITLE
Fix spacing around generics with some composite type arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed spacing around generics with composite type parameters (e.g. `array of`, `set of`).
+- Fixed spacing around generics with composite type parameters (e.g. `array of`, `set of`, `string[10]`).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed spacing around generics with composite type parameters (e.g. `array of`, `set of`).
+
 ### Changed
 
 - Allow case arm statements to be formatted inline.

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `ConditionalDirectiveConsolidator` to combine _simple_ conditional statements into a single `LogicalLine`.
+- Added `KeywordKind::is_numeric_operator`.
 
 ## [0.4.0-rc1] - 2025-02-20
 

--- a/core/src/lang.rs
+++ b/core/src/lang.rs
@@ -229,6 +229,19 @@ impl KeywordKind {
                 | KeywordKind::Stored
         )
     }
+
+    pub fn is_numeric_operator(&self) -> bool {
+        matches!(
+            self,
+            KeywordKind::And
+                | KeywordKind::Or
+                | KeywordKind::Xor
+                | KeywordKind::Shl
+                | KeywordKind::Shr
+                | KeywordKind::Div
+                | KeywordKind::Mod
+        )
+    }
 }
 
 /// Used to distinguish the semantic meanings of `=`

--- a/core/src/rules/generics_consolidator.rs
+++ b/core/src/rules/generics_consolidator.rs
@@ -42,7 +42,10 @@ impl TokenConsolidator for DistinguishGenericTypeParamsConsolidator {
                             KeywordKind::Class
                             | KeywordKind::Record
                             | KeywordKind::Constructor
-                            | KeywordKind::String,
+                            | KeywordKind::String
+                            | KeywordKind::Array
+                            | KeywordKind::Set
+                            | KeywordKind::Of,
                         ),
                     ) => {}
                     Some(TokenType::Op(OperatorKind::GreaterThan(_))) => {
@@ -207,6 +210,23 @@ mod tests {
 
         // A<String>
         run_test(&[ID, LT, STRING, GT], &[ID, LG, STRING, RG])
+    }
+
+    #[test]
+    fn composite_types() {
+        const SET: TokenType = TokenType::Keyword(KeywordKind::Set);
+        const ARRAY: TokenType = TokenType::Keyword(KeywordKind::Array);
+        const OF: TokenType = TokenType::Keyword(KeywordKind::Of);
+
+        // A<set of B>
+        run_test(&[ID, LT, SET, OF, ID, GT], &[ID, LG, SET, OF, ID, RG]);
+        // A<array of B>
+        run_test(&[ID, LT, ARRAY, OF, ID, GT], &[ID, LG, ARRAY, OF, ID, RG]);
+        // A<array of set of B>
+        run_test(
+            &[ID, LT, ARRAY, OF, SET, OF, ID, GT],
+            &[ID, LG, ARRAY, OF, SET, OF, ID, RG],
+        );
     }
 
     #[test]

--- a/core/src/rules/token_spacing.rs
+++ b/core/src/rules/token_spacing.rs
@@ -375,6 +375,10 @@ mod tests {
         two_generic_params_in_property_type_before_read = {"property Foo : TFoo < A ,  B > read FFoo", "property Foo: TFoo<A, B> read FFoo"},
         one_generic_param_in_property_type_before_write = {"property Foo : TFoo < A > write FFoo", "property Foo: TFoo<A> write FFoo"},
         two_generic_params_in_property_type_before_write = {"property Foo : TFoo < A ,  B > write FFoo", "property Foo: TFoo<A, B> write FFoo"},
+
+        array_of = {"A = B < array of C >", "A = B<array of C>"},
+        set_of = {"A = B < set of C >", "A = B<set of C>"},
+        array_of_set_of = {"A = B < array of set of C >", "A = B<array of set of C>"},
     );
 
     formatter_test_group!(

--- a/core/src/rules/token_spacing.rs
+++ b/core/src/rules/token_spacing.rs
@@ -379,6 +379,24 @@ mod tests {
         array_of = {"A = B < array of C >", "A = B<array of C>"},
         set_of = {"A = B < set of C >", "A = B<set of C>"},
         array_of_set_of = {"A = B < array of set of C >", "A = B<array of set of C>"},
+
+        short_string = {"A = B < string[10] >", "A = B<string[10]>"},
+        short_string_comment_between = {"A = B < string{}[10] >", "A = B<string {} [10]>"},
+        short_string_expr = {
+            "A = B < string[10 + C * (1 shl 8 shr 2 and 1 or 2 xor 1 div 2 mod 2) + D<B> / 2] >",
+            "A = B<string[10 + C * (1 shl 8 shr 2 and 1 or 2 xor 1 div 2 mod 2) + D<B> / 2]>"
+        },
+        short_string_nested_expr = {
+            "A = B < string[10 + SizeOf(C<string[(10 + 1) * 2]>)] >",
+            "A = B<string[10 + SizeOf(C<string[(10 + 1) * 2]>)]>"
+        },
+        short_string_unmatched_parens = {"A = B < string[(] >", "A = B<string[(]>"},
+        // this case is more of a quirk of the implementation, rather than 'correct' behaviour.
+        short_string_unmatched_brack = {"A = B < string[ A<[> ] >", "A = B<string[A<[>]>"},
+        // only 'operator' keywords are allowed in the brackets
+        short_string_unexpected_keyword = {"A = B < string[begin] >", "A = B < string[begin] >"},
+        short_string_cmp_expr = {"A = B < string[ (C<D)<E ] >", "A = B<string[(C < D) < E]>"},
+        short_string_nested_bracks = {"A = B < string[ C[0] < 0 ] >", "A = B<string[C[0] < 0]>"},
     );
 
     formatter_test_group!(


### PR DESCRIPTION
Fixes #171.

I realised when fixing this that
```delphi
type A = B<string[10]>
```
was also a problem, and it only gets worse when you realise that the number can be any const expression:
```delphi
type A = B<string[10 + (1 shl 8) div 10 + SizeOf(C)]>
```