### PR TITLE
Support formatting simple conditional directives inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Allow case arm statements to be formatted inline.
+- Allow simple conditionally compiled code to be formatted inline.
 
 ## [0.4.0-rc1] - 2025-02-20
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Stopped deleting "voided" lines.
+
 ## [0.4.0-rc1] - 2025-02-20
 
 ### Fixed

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Stopped deleting "voided" lines.
 
+### Added
+
+- Added `ConditionalDirectiveConsolidator` to combine _simple_ conditional statements into a single `LogicalLine`.
+
 ## [0.4.0-rc1] - 2025-02-20
 
 ### Fixed

--- a/core/datatests/generators/optimising_line_formatter.rs
+++ b/core/datatests/generators/optimising_line_formatter.rs
@@ -24,6 +24,7 @@ mod directives {
 
     pub fn generate(root_dir: &Path) {
         conditional::generate(root_dir);
+        consolidated_conditional::generate(root_dir);
         compiler::generate(root_dir);
     }
 
@@ -72,6 +73,259 @@ mod directives {
                           ;
                     end;
                 ",
+            );
+        }
+    }
+
+    mod consolidated_conditional {
+        use super::*;
+
+        pub fn generate(root_dir: &Path) {
+            generate_test_cases!(
+                root_dir,
+                if_else_invocation = "
+                    // wrap_column=40                       |
+                    A({$if} B {$else} C {$endif});
+                    AAAAAAAAAAAA(
+                        {$if} B {$elseif} C {$endif}
+                    );
+                    AAAAAAAAAAAA(
+                        {$if} BB {$else} CC {$endif}
+                    );
+                    AAAAAAAAAAAA(
+                        {$if}
+                        BBBBBBB
+                        {$else}
+                        CCCCCC
+                        {$endif}
+                    );
+                    AAAAAAAAAAAA(
+                        {$if}
+                        BBB.BBB
+                        {$elseif}
+                        CCC.CCC
+                        {$endif}
+                    );
+                    AAAAAAAAAAAA(
+                        {$if} B {$else} C {$endif},
+                        A,
+                    );
+                    AAAAAAAAAAAA(
+                        {$if}
+                        BBBBBBB
+                        {$elseif}
+                        CCCCCC
+                        {$endif},
+                        A
+                    );
+                ",
+                if_invocation = "
+                    // wrap_column=40                       |
+                    AAAAAAAAAAAAAAA({$if} B {$endif}, C, D);
+                    AAAAAAAAAAAAAAAA(
+                        {$if} B {$endif},
+                        C,
+                        D
+                    );
+                    AAAAAAAAAAAAAAAA(
+                        {$if}
+                        BBBBBBBBBBBBBBBBBBBBB
+                        {$endif},
+                        C,
+                        D
+                    );
+                ",
+                if_else_const = "
+                    // wrap_column=40                       |
+                    const
+                      A = {$if} BBBBB {$else} CCCC {$endif};
+                      AA =
+                          {$if} BBBBB {$else} CCCC {$endif};
+                      AA =
+                          {$if}
+                          BBBBBB
+                          {$else}
+                          CCCCCC
+                          {$endif};
+                      A: T = (
+                          A: {$if} A {$else} B {$endif};
+                          B: {$if} A {$elseif} B {$endif}
+                      );
+                ",
+                if_const = "
+                    // wrap_column=40                       |
+                    const
+                      AAAAAAAAAAAAAA = {$if} BBBBB {$endif};
+                      AAAAAAAAAAAAAAA =
+                          {$if} BBBBB {$endif};
+                      AAAAAAAAAAAAAAA =
+                          {$if}
+                          BBBBBBBBBBBBBBBBBBB
+                          {$endif};
+                ",
+                if_else_assignment = "
+                    // wrap_column=40                       |
+                    A := {$if} BBBBB {$else} CCCCC {$endif};
+                    AAA :=
+                        {$if} BBBB {$elseif} CCCC {$endif};
+                    AA :=
+                        {$if}
+                        BBBBBB
+                        {$else}
+                        CCCCCC
+                        {$endif};
+                ",
+                if_assignment = "
+                    // wrap_column=40                       |
+                    AAAAAAAAAAAAA := {$if} BBBBBBB {$endif};
+                    AAAAAAAAAAAAAA :=
+                        {$if} BBBBBBB {$endif};
+                    AAAAAAAAAAAAAA :=
+                        {$if}
+                        BBBBBBBBBBBBBBBBBBBBB
+                        {$endif};
+                ",
+                if_else_types = "
+                    // wrap_column=40                       |
+                    type
+                      AA = class({$if} B {$else} C {$endif})
+                        AAA: {$if} B {$else} C {$endif};
+                        AAAAAAAA:
+                            {$if} B {$else} C {$endif};
+                        AAAAAAAA:
+                            {$if}
+                            BBBBB
+                            {$else}
+                            CCCCC
+                            {$endif};
+                        AAA: T<{$if} B {$else} C {$endif}>;
+                        AAAAAAAA:
+                            T<{$if} B {$elseif} C {$endif}>;
+                        AAAAAAAA:
+                            T<
+                                {$if}
+                                BBBBB
+                                {$else}
+                                CCCCC
+                                {$endif}
+                            >;
+                      end;
+                      AAA =
+                          class({$if} B {$else} C {$endif})
+                      end;
+                      AAA =
+                          class(
+                              {$if} BB {$elseif} CC {$endif}
+                          )
+                      end;
+                      AAA =
+                          class(
+                              {$if}
+                              BBBB
+                              {$else}
+                              CCCC
+                              {$endif}
+                          )
+                      end;
+                ",
+                if_types = "
+                    // wrap_column=40                       |
+                    type
+                      AA = class({$if} BBBBBBBBBBB {$endif})
+                        AAA: {$if} BBBBBBBBBBB {$endif};
+                        AAAAAAAA:
+                            {$if} BBBBBBBBBBB {$endif};
+                        AAAAAAAA:
+                            {$if}
+                            BBBBBBBBBBBBBBBBBBBBB
+                            {$endif};
+                        AAA: T<{$if} BBBBBBBBBBB {$endif}>;
+                        AAAAAAAA:
+                            T<{$if} BBBBBBBBBBB {$endif}>;
+                        AAAAAAAA:
+                            T<
+                                {$if}
+                                BBBBBBBBBBBBBBBBBBBBBBBBBB
+                                {$endif}
+                            >;
+                      end;
+                      AAA =
+                          class({$if} BBBBBBBBBBB {$endif})
+                      end;
+                      AAA =
+                          class(
+                              {$if} BBBBBBBBBBBBB {$endif}
+                          )
+                      end;
+                      AAA =
+                          class(
+                              {$if}
+                              BBBBBBBBBBBBBBBBBBBBBBB
+                              {$endif}
+                          )
+                      end;
+                ",
+                other = "
+                    // wrap_column=90                                                                         |
+                    A := [{$if} A {$else} B {$endif}];
+                    A := ({$if} A {$else} B {$endif});
+                    A := A({$if} A {$else} B {$endif}, {$if} A {$else} B {$endif});
+                    A :=
+                        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA(
+                            {$if} A {$else} B {$endif},
+                            {$if} A {$else} B {$endif}
+                        );
+                    A :=
+                        {$if} A {$else} B {$endif}
+                            + {$if} A {$else} B {$endif};
+                    A :=
+                        {$if} A.A {$else} B.B {$endif}
+                            + {$if} A.A {$else} B.B {$endif};
+                    A :=
+                        A. {$if} A {$else} B {$endif}
+                            (
+                                {$if} A.A {$else} B.B {$endif}
+                                    + {$if} A.A {$else} B.B {$endif};
+                            );
+                    A := {$if} AAAA. {$else} AAAA. {$endif} BBBB;
+                    AAAAAA :=
+                        {$if} AAAAAAAAAAAAAAAAAA. {$else} AAAAAAAAAAAAAAAAAA. {$endif} BBBBBBBBBBBBBBBBB;
+                ",
+                routine_heading = "
+                    // wrap_column=90                                                                         |
+                    interface
+                    procedure {$IFDEF} AAAAAAA {$ELSE} BBBBBBBB {$ENDIF}.CCCCCCCCCC(AAAAAAAAAAAA: BBBBBBBBBB);
+                    procedure {$IFDEF} AAAAAAA {$ELSE} BBBBBBBB {$ENDIF}.CCCCCCCCCCCCCC(
+                        AAAAAAAAAAAA: BBBBBBBBBB
+                    );
+                    procedure {$IFNDEF} AAAAAAAAAAAAAAAAA {$ELSE} BBBBBBBBBBBBBBBBB {$ENDIF}.CCCCCCCCCCCCCCCCC(
+                        DDDDDD: DDDDDDDDD;
+                        DDDDDD: DDDDDDDDD;
+                    );
+                ",
+                dot_wrapping = "
+                    A :=
+                        {$if}
+                        AAAA.
+                        {$else}
+                        AAAA.
+                        {$endif}
+                            BBBB;
+                    A :=
+                        {$if}
+                        AAAA.BBBB
+                        {$else}
+                        AAAA.BBBB
+                        {$endif};
+                    A :=
+                        {$if}
+                        AAAAAAAAAAAAA
+                            .BBBBBBBBBBBBB
+                        {$else}
+                        AAAAAAAAAAAAA
+                            .BBBBBBBBBBBBB
+                        {$endif};
+                "
             );
         }
     }
@@ -355,11 +609,11 @@ mod comments {
                 root_dir,
                 after = "
                     Foo(
-                    {$ifdef A} //
+                        {$ifdef A} //
                         A
-                    {$else} //
+                        {$else} //
                         B
-                    {$endif} //
+                        {$endif} //
                     );
                 ",
             );

--- a/core/src/defaults/parser.rs
+++ b/core/src/defaults/parser.rs
@@ -101,7 +101,7 @@ fn parse_file(tokens: &mut [RawToken]) -> Vec<LogicalLine> {
                 tokens: vec![token_index],
                 line_type: LLT::CompilerDirective,
             }),
-            TT::ConditionalDirective(CDK::If | CDK::Ifdef | CDK::Ifndef | CDK::Ifopt) => {
+            TT::ConditionalDirective(kind) if kind.is_if() => {
                 directive_lines.push(LocalLogicalLine {
                     parent: None,
                     level: directive_level,
@@ -110,7 +110,7 @@ fn parse_file(tokens: &mut [RawToken]) -> Vec<LogicalLine> {
                 });
                 directive_level += 1;
             }
-            TT::ConditionalDirective(CDK::Endif | CDK::Ifend) => {
+            TT::ConditionalDirective(kind) if kind.is_end() => {
                 directive_level = directive_level.saturating_sub(1);
                 directive_lines.push(LocalLogicalLine {
                     parent: None,
@@ -119,7 +119,7 @@ fn parse_file(tokens: &mut [RawToken]) -> Vec<LogicalLine> {
                     line_type: LLT::ConditionalDirective,
                 });
             }
-            TT::ConditionalDirective(CDK::Else | CDK::Elseif) => {
+            TT::ConditionalDirective(kind) if kind.is_else() => {
                 directive_lines.push(LocalLogicalLine {
                     parent: None,
                     level: directive_level.saturating_sub(1),

--- a/core/src/lang.rs
+++ b/core/src/lang.rs
@@ -325,6 +325,18 @@ pub enum ConditionalDirectiveKind {
     Endif,
 }
 
+impl ConditionalDirectiveKind {
+    pub(crate) fn is_if(&self) -> bool {
+        matches!(self, Self::If | Self::Ifdef | Self::Ifndef | Self::Ifopt)
+    }
+    pub(crate) fn is_else(&self) -> bool {
+        matches!(self, Self::Else | Self::Elseif)
+    }
+    pub(crate) fn is_end(&self) -> bool {
+        matches!(self, Self::Endif | Self::Ifend)
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum TextLiteralKind {
     SingleLine,
@@ -435,6 +447,9 @@ impl LogicalLine {
     }
     pub fn get_parent(&self) -> Option<LineParent> {
         self.parent
+    }
+    pub fn set_parent(&mut self, parent: Option<LineParent>) {
+        self.parent = parent;
     }
     pub fn get_level(&self) -> u16 {
         self.level

--- a/core/src/lang.rs
+++ b/core/src/lang.rs
@@ -448,9 +448,6 @@ impl LogicalLine {
     pub fn get_parent(&self) -> Option<LineParent> {
         self.parent
     }
-    pub fn set_parent(&mut self, parent: Option<LineParent>) {
-        self.parent = parent;
-    }
     pub fn get_level(&self) -> u16 {
         self.level
     }

--- a/core/src/rules/conditional_directive_consolidator.rs
+++ b/core/src/rules/conditional_directive_consolidator.rs
@@ -1,0 +1,420 @@
+use itertools::Itertools;
+
+use crate::{
+    lang::{
+        CommentKind, LogicalLine, LogicalLineType, OperatorKind, TextLiteralKind, Token, TokenData,
+        TokenType,
+    },
+    traits::LogicalLinesConsolidator,
+};
+use TokenType as TT;
+
+pub struct ConditionalDirectiveConsolidator {}
+impl ConditionalDirectiveConsolidator {
+    fn is_allowed_token(tokens: &[Token], token_index: usize) -> bool {
+        matches!(
+            tokens.get(token_index).map(Token::get_token_type),
+            Some(
+                TT::Identifier
+                    | TT::NumberLiteral(_)
+                    | TT::TextLiteral(TextLiteralKind::SingleLine)
+                    | TT::Comment(
+                        CommentKind::IndividualBlock
+                            | CommentKind::IndividualLine
+                            | CommentKind::InlineBlock
+                            | CommentKind::InlineLine
+                    )
+                    | TT::Op(OperatorKind::Dot),
+            )
+        )
+    }
+
+    fn expand_line(tokens: &[Token], line: &mut LogicalLine) -> Vec<usize> {
+        let line_tokens = line.get_tokens();
+        let (Some(&first_token), Some(&last_token)) = (line_tokens.first(), line_tokens.last())
+        else {
+            return vec![];
+        };
+
+        if last_token - first_token + 1 == line_tokens.len() {
+            // if this equality holds, the tokens are sequential and there is
+            // nothing to do
+            return vec![];
+        }
+
+        enum ConditionalState {
+            Outside,
+            AfterIf,
+            AfterElse,
+        }
+        use ConditionalState as CS;
+
+        let mut state = ConditionalState::Outside;
+        let mut directives: Vec<usize> = Vec::with_capacity(3);
+        let mut new_line_tokens = vec![first_token];
+
+        for (&prev, &current) in line.get_tokens().iter().tuple_windows() {
+            if current - prev > 1 {
+                let gap_start_tok = prev + 1;
+                let gap_end_tok = current - 1;
+                match (
+                    tokens.get(gap_start_tok).map(Token::get_token_type),
+                    tokens.get(gap_end_tok).map(Token::get_token_type),
+                ) {
+                    (
+                        Some(TT::ConditionalDirective(b_kind)),
+                        Some(TT::ConditionalDirective(e_kind)),
+                    ) => match &state {
+                        CS::Outside if b_kind.is_if() => {
+                            state = match e_kind {
+                                _ if gap_start_tok == gap_end_tok => CS::AfterIf,
+                                k if k.is_else() => CS::AfterElse,
+                                _ => return vec![],
+                            };
+                        }
+                        CS::AfterIf if b_kind.is_else() => {
+                            state = match e_kind {
+                                _ if gap_start_tok == gap_end_tok => CS::AfterElse,
+                                k if k.is_end() => CS::Outside,
+                                _ => return vec![],
+                            };
+                        }
+                        CS::AfterIf | CS::AfterElse
+                            if b_kind.is_end() && gap_start_tok == gap_end_tok =>
+                        {
+                            state = CS::Outside;
+                        }
+                        // the gap is an excluded conditional directive pattern
+                        _ => return vec![],
+                    },
+                    // the gap is not conditionally excluded code
+                    _ => return vec![],
+                }
+
+                directives.push(gap_start_tok);
+                new_line_tokens.push(gap_start_tok);
+
+                for gap_token in (gap_start_tok..gap_end_tok).skip(1) {
+                    if Self::is_allowed_token(tokens, gap_token) {
+                        new_line_tokens.push(gap_token);
+                    } else {
+                        return vec![];
+                    }
+                }
+
+                if gap_end_tok != gap_start_tok {
+                    directives.push(gap_end_tok);
+                    new_line_tokens.push(gap_end_tok);
+                }
+            }
+
+            if !(matches!(state, CS::Outside) || Self::is_allowed_token(tokens, current)) {
+                return vec![];
+            }
+            new_line_tokens.push(current);
+        }
+
+        if directives.is_empty() || !matches!(state, ConditionalState::Outside) {
+            // there were no or incomplete directives in the line, ignore
+            return vec![];
+        }
+
+        // Add all non-conditional tokens, merging the lines
+        *line.get_tokens_mut() = new_line_tokens;
+        directives
+    }
+}
+impl LogicalLinesConsolidator for ConditionalDirectiveConsolidator {
+    fn consolidate(&self, (tokens, lines): (&mut [Token], &mut [LogicalLine])) {
+        let mut directive_tokens: Vec<usize> = Vec::new();
+        for line in lines.iter_mut() {
+            directive_tokens.extend(Self::expand_line(tokens, line));
+        }
+
+        // In theory, it could be more efficient later to deduplicate the
+        // expanded lines. This is more complicated than it is worth to ensure
+        // all child lines' parent remain correct.
+
+        let first_token =
+            |line: &&mut LogicalLine| line.get_tokens().first().copied().unwrap_or_default();
+
+        directive_tokens.sort();
+        directive_tokens.dedup();
+
+        let mut directive_lines = lines
+            .iter_mut()
+            .filter(|line| line.get_line_type() == LogicalLineType::ConditionalDirective)
+            .sorted_by_key(first_token)
+            .collect_vec();
+
+        for directive in &directive_tokens {
+            if let Ok(directive_line) = directive_lines.binary_search_by_key(directive, first_token)
+            {
+                directive_lines[directive_line].void_and_drain();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use crate::prelude::*;
+
+    use super::*;
+
+    fn consolidate_n_times(tokens: &mut [Token], lines: &mut [LogicalLine], n: u8) {
+        for _ in 0..n {
+            ConditionalDirectiveConsolidator {}.consolidate((tokens, lines));
+        }
+    }
+
+    fn format_input(input: &str, n: u8) -> String {
+        let tokens = DelphiLexer {}.lex(input);
+        let (mut lines, mut tokens) = DelphiLogicalLineParser {}.parse(tokens);
+        consolidate_n_times(&mut tokens, &mut lines, n);
+        let mut formatted_tokens =
+            FormattedTokens::new_from_tokens(&tokens, &TokenMarker::default());
+        for line in lines {
+            if let Some(&first) = line.get_tokens().first() {
+                let data = formatted_tokens
+                    .get_formatting_data_mut(first)
+                    .expect("Formatting data should exist for the first token");
+                data.spaces_before = 0;
+                data.newlines_before = if first == 0
+                    || matches!(
+                        line.get_line_type(),
+                        LogicalLineType::Eof | LogicalLineType::Voided
+                    ) {
+                    0
+                } else {
+                    1
+                };
+            }
+            for &token in line.get_tokens().iter().skip(1) {
+                let data = formatted_tokens
+                    .get_formatting_data_mut(token)
+                    .expect("Formatting data should exist for the line token");
+                data.spaces_before = 1;
+                data.newlines_before = 0;
+            }
+        }
+
+        let mut out = String::new();
+        DelphiLogicalLinesReconstructor::new(default_test_reconstruction_settings())
+            .reconstruct(formatted_tokens, &mut out);
+        out
+    }
+
+    fn assert_unchanged(input: &str) {
+        assert_eq!(input, format_input(input, 1), "Input should be unchanged");
+    }
+
+    fn assert_unchanged_repeated_consolidation(input: &str) {
+        assert_eq!(input, format_input(input, 2), "Input should be unchanged");
+    }
+
+    #[test]
+    fn no_conditional_directives() {
+        assert_unchanged("A := B ;");
+        assert_unchanged("A := B + C ;");
+    }
+
+    #[test]
+    fn simple_if_conditional_directives() {
+        assert_unchanged("A := {$ifdef A} B {$endif} + C ;");
+        assert_unchanged("A := {$ifndef A} B {$endif} + C ;");
+        assert_unchanged("A := {$ifopt A} B {$endif} + C ;");
+        assert_unchanged("A := {$if A} B {$ifend} + C ;");
+        assert_unchanged(
+            "\
+            A := B\n\
+            {$ifdef} + B\n\
+            {$endif} ;",
+        );
+    }
+
+    #[test]
+    fn simple_if_else_conditional_directives() {
+        assert_unchanged("A := {$ifdef A} B1 {$else} B2 {$endif} + C ;");
+        assert_unchanged("A := {$ifndef A} B1 {$elseif} B2 {$endif} + C ;");
+        assert_unchanged("A := {$ifopt A} B1 {$else} B2 {$endif} + C ;");
+        assert_unchanged("A := {$if A} B1 {$elseif} B2 {$ifend} + C ;");
+        assert_unchanged("A := {$if A} B1 {} {$else} B2 {} {$ifend} + C ;");
+        assert_unchanged(
+            "\
+            A := B\n\
+            {$ifdef} + B1\n\
+            {$else} + B2\n\
+            {$endif} ;",
+        );
+    }
+
+    #[test]
+    fn repeated_consolidation() {
+        assert_unchanged_repeated_consolidation("A := {$ifdef A} B1 {$else} B2 {$endif} + C ;");
+        assert_unchanged_repeated_consolidation(
+            "\
+            A := B\n\
+            {$ifdef} + B1\n\
+            {$else} + B2\n\
+            {$endif} ;",
+        );
+    }
+
+    #[test]
+    fn simple_child_line_if_else_conditional_directives() {
+        assert_unchanged(
+            "\
+            if A then\n\
+            A := {$ifdef A} B1 {$else} B2 {$endif} + C ;",
+        );
+        assert_unchanged(
+            "\
+            for A in b do\n\
+            A := {$ifndef A} B1 {$elseif} B2 {$endif} + C ;",
+        );
+        assert_unchanged(
+            "\
+            while A do\n\
+            A := {$ifopt A} B1 {$else} B2 {$endif} + C ;",
+        );
+        assert_unchanged(
+            "\
+            with A do\n\
+            A := {$if A} B1 {$elseif} B2 {$ifend} + C ;",
+        );
+        assert_unchanged(
+            "\
+            if A then\n\
+            A := {$if A} B1 {} {$else} B2 {} {$ifend} + C ;",
+        );
+        assert_unchanged(
+            "\
+            while A do\n\
+            A := B\n\
+            {$ifdef} + B1\n\
+            {$else} + B2\n\
+            {$endif} ;",
+        );
+    }
+
+    #[test]
+    fn identifier_chaining_if_else_conditional_directives() {
+        assert_unchanged("A := {$ifdef A} B1 . B2 {$else} B1 . B2 {$endif} + C ;");
+        assert_unchanged("A := {$ifdef A} B1 . B2 . B3 {$else} B1 . B2 . B3 {$endif} + C ;");
+    }
+
+    #[test]
+    fn if_else_on_whole_child_lines() {
+        assert_unchanged(
+            "\
+            if A then\n\
+            begin\n\
+            {$ifdef A}\n\
+            A := B ;\n\
+            {$else}\n\
+            C := D . E ;\n\
+            {$endif}\n\
+            end ;",
+        );
+    }
+
+    #[test]
+    fn ignored_cases() {
+        assert_unchanged(
+            "\
+            A :=\n\
+            {$ifdef A} A + B\n\
+            {$else} C + D\n\
+            {$endif} + E ;",
+        );
+        assert_unchanged(
+            "\
+            A :=\n\
+            {$ifndef A} A ( )\n\
+            {$else} B ( )\n\
+            {$endif} ;",
+        );
+        assert_unchanged(
+            "\
+            A := A (\n\
+            {$ifopt A} )\n\
+            {$else} )\n\
+            {$endif} ;",
+        );
+        assert_unchanged(
+            "\
+            type\n\
+            A = packed record\n\
+            {$if} //\n\
+            F : F ;\n\
+            end ;",
+        );
+        assert_unchanged(
+            "\
+            A := procedure begin\n\
+            {$if A}\n\
+            B1 ; end\n\
+            {$else}\n\
+            B2 ; end\n\
+            {$endif} ;",
+        );
+        assert_unchanged(
+            "\
+            A := procedure begin\n\
+            B1 ; end ;\n\
+            {$if}\n\
+            {$endif}",
+        );
+        assert_unchanged(
+            "\
+            A :=\n\
+            {$if} {
+                Multiline comment
+            }\n\
+            {$endif}",
+        );
+        assert_unchanged(
+            "\
+            A :=\n\
+            {$ifdef A}\n\
+            {$elseif} A\n\
+            {$else} A\n\
+            {$endif} + E ;",
+        );
+    }
+
+    #[test]
+    fn ignored_nested_directive_cases() {
+        assert_unchanged(
+            "\
+            A :=\n\
+            {$ifdef A}\n\
+            {$if} A\n\
+            {$endif}\n\
+            {$else}\n\
+            {$if} A\n\
+            {$endif}\n\
+            {$endif} + E ;",
+        );
+        assert_unchanged(
+            "\
+            A :=\n\
+            {$ifdef A}\n\
+            {$if} A\n\
+            {$endif}\n\
+            {$endif} + E ;",
+        );
+        assert_unchanged(
+            "\
+            {$if}\n\
+            A :=\n\
+            {$if} A\n\
+            {$else} B\n\
+            {$endif}\n\
+            {$endif} ;",
+        );
+    }
+}

--- a/core/src/rules/mod.rs
+++ b/core/src/rules/mod.rs
@@ -1,3 +1,4 @@
+pub mod conditional_directive_consolidator;
 pub mod eof_newline;
 pub mod formatting_toggle;
 pub mod generics_consolidator;
@@ -6,6 +7,7 @@ pub mod ignore_non_unit_import_clauses;
 pub mod optimising_line_formatter;
 pub mod token_spacing;
 
+pub use conditional_directive_consolidator::*;
 pub use eof_newline::*;
 pub use formatting_toggle::*;
 pub use generics_consolidator::*;

--- a/front-end/src/lib.rs
+++ b/front-end/src/lib.rs
@@ -303,6 +303,7 @@ pub fn make_formatter(config: &FormattingConfig) -> Formatter {
         .lexer(DelphiLexer {})
         .parser(DelphiLogicalLineParser {})
         .token_consolidator(DistinguishGenericTypeParamsConsolidator {})
+        .lines_consolidator(ConditionalDirectiveConsolidator {})
         .token_ignorer(FormattingToggler {})
         .token_ignorer(IgnoreNonUnitImportClauses {})
         .token_ignorer(IgnoreAsmIstructions {})


### PR DESCRIPTION
This PR fixes #169.

Conditionally compiled code can be formatted inline in a few particular cases:
* If there are only identifiers, literals, and dots within the conditional code
* There are no intra-line nested conditionals

If the line is deemed "too complex" the old formatting style will be followed.
Additionally, removing the `ConditionalDirectiveConsolidator` from the formatter definition produces the same formatting as before.