### PR TITLE
Fix fields being merged with comments in variant records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed spacing around generics with composite type parameters (e.g. `array of`, `set of`, `string[10]`).
+- Fixed fields being merged with comments in variant records.
+- Fixed end of line comment placement after compiler directives.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,7 @@ dependencies = [
  "fxhash",
  "indoc",
  "itertools 0.12.1",
+ "log",
  "pasfmt-core",
  "pretty_assertions",
  "spectral",

--- a/core/datatests/Cargo.toml
+++ b/core/datatests/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dev-dependencies]
 datatest-stable = { workspace = true }
+log = { workspace = true }
 pasfmt-core = { path = "..", features = [ "_lang_types_from_str" ] }
 spectral = { workspace = true }
 indoc = { workspace = true }

--- a/core/datatests/generators/optimising_line_formatter.rs
+++ b/core/datatests/generators/optimising_line_formatter.rs
@@ -594,7 +594,11 @@ mod comments {
                       case AAA of
                         BBB: ( //
                           F: FFF;
-                        )
+                        );
+                        BBB: (
+                          //
+                          F: FFF;
+                        );
                       end;
                 ",
             );
@@ -615,6 +619,10 @@ mod comments {
                         B
                         {$endif} //
                     );
+                    {$if}
+                      {$define A} //
+                      {$define A} {} {}
+                    {$endif}
                 ",
             );
         }

--- a/core/src/rules/optimising_line_formatter/requirements.rs
+++ b/core/src/rules/optimising_line_formatter/requirements.rs
@@ -27,7 +27,7 @@ impl InternalOptimisingLineFormatter<'_, '_> {
 
         let parents_support_break = contexts_data.parents_support_break();
 
-        if let Some(value) = self.require_formatting_invariants(line_index, line) {
+        if let Some(value) = self.get_formatting_invariant(line_index, line) {
             return value.map_can_break(parents_support_break);
         }
 
@@ -312,7 +312,7 @@ impl InternalOptimisingLineFormatter<'_, '_> {
         requirement.map_can_break(parents_support_break)
     }
 
-    fn require_formatting_invariants(
+    pub(super) fn get_formatting_invariant(
         &self,
         line_index: u32,
         line: &LogicalLine,
@@ -321,6 +321,7 @@ impl InternalOptimisingLineFormatter<'_, '_> {
             self.get_prev_token_type_for_line_index(line, line_index),
             self.get_token_type_for_line_index(line, line_index),
         ) {
+            (None, _) => Some(DR::MustNotBreak),
             (_, Some(TT::Comment(CommentKind::InlineLine | CommentKind::InlineBlock))) => {
                 Some(DR::MustNotBreak)
             }


### PR DESCRIPTION
This fixes a bug in variant records. If there is a comment in the variant field definitions, the fields would erroneously get merged into the comment.