### PR TITLE
Add safety check for line breaks after single-line comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed spacing around generics with composite type parameters (e.g. `array of`, `set of`, `string[10]`).
 - Fixed fields being merged with comments in variant records.
+  A safety check has been added to prevent bugs of this kind in the future.
 - Fixed end of line comment placement after compiler directives.
 
 ### Changed

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `ConditionalDirectiveConsolidator` to combine _simple_ conditional statements into a single `LogicalLine`.
 - Added `KeywordKind::is_numeric_operator`.
+- Added `CommentKind::is_singleline`.
 
 ## [0.4.0-rc1] - 2025-02-20
 

--- a/core/src/lang.rs
+++ b/core/src/lang.rs
@@ -326,6 +326,12 @@ pub enum CommentKind {
     IndividualLine,
 }
 
+impl CommentKind {
+    pub fn is_singleline(&self) -> bool {
+        matches!(self, CommentKind::InlineLine | CommentKind::IndividualLine)
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum ConditionalDirectiveKind {
     If,


### PR DESCRIPTION
As discovered recently (#181), it's possible for subtle bugs to slip in
that result in a missing line break after a single-line comment.

While we strive to never let this happen, it's a good idea to make
*sure* that it doesn't happen. With this change, the missing line break
will be detected and inserted. The formatting won't be great after a
line break is suddenly inserted, but that's better than broken.
