### PR TITLE
Void totally ignored lines

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Stopped deleting "voided" lines.
+- Void lines which consist of only ignored tokens.
+  This is closer to what a user would expect from the action of 'disabling' formatting; they may
+  be using the `{pasfmt off}` comment to get around some performance issue, or some error.
 
 ### Added
 


### PR DESCRIPTION
A user might expect that they could use the `{pasfmt off}` comment to
get around a performance issue, or an error in one of the formatting
rules (e.g. 'no solution found'). However, since disabling formatting
works at the token level and not the line level, this isn't how it works
in practice.

This PR improves things by 'voiding' any line which consists of only
ignored tokens. Voiding the line means that none of the later formatting
rules will process it at all.
