### PR TITLE
Use tag as release name in `Release` workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          name: ${{ steps.changelog.outputs.version }}
+          name: ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.release-notes }}
           tag_name: ${{ github.ref_name }}
           draft: true


### PR DESCRIPTION
This has the effect of adding the `v` to the start of the draft release titles.