### PR TITLE
Ignore tokens between uses and import list in non-units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed conditional directives not being ignored between `uses` and import list in non-units.
+
 ## [0.4.0-rc2] - 2025-03-12
 
 ### Fixed


### PR DESCRIPTION
This PR fixes the bug noticed here #193.

This bug was created when the `uses` and the import list were split onto their own lines. The clause ignorer was only ignoring tokens within the range of the import list.

This change ensures all tokens between the `uses` and `;` will be ignored.