### PR TITLE
Fix parsing of structures after a label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed formatting of structures after a label.
+
 ## [0.4.0] - 2025-03-18
 
 ### Changed

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed parsing of structures after labels.
+
 ## [0.4.0] - 2025-03-18
 
 ### Added

--- a/core/datatests/generators/logical_line_parser.rs
+++ b/core/datatests/generators/logical_line_parser.rs
@@ -2847,6 +2847,13 @@ mod statements {
                     _|  Bar();
                     _|end
                 ",
+                label_if_statement = "
+                    _  |begin
+                    _  |  %111:
+                    _1 |  if A then{1}
+                    _^1|    B;
+                    _  |end
+                ",
                 other_contexts = "
                     _|begin
                     _|  repeat

--- a/core/src/defaults/parser.rs
+++ b/core/src/defaults/parser.rs
@@ -1161,6 +1161,7 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
                     self.next_token(); // Label specifier
                     self.next_token(); // Colon
                     self.finish_logical_line();
+                    return;
                 }
                 _ => self.next_token(),
             }


### PR DESCRIPTION
This fixes #209

After labels, the parser wasn't returning to the right state to format structured statements.