### PR TITLE
Fix parsing of visibility specifiers outside type declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed formatting of structures after a label.
+- Visibility specifiers (e.g. `private`, `public`) are no longer treated like section headers when
+  used outside type declarations.
 
 ## [0.4.0] - 2025-03-18
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed parsing of structures after labels.
+- Parsing of visibility specifiers used as identifers outside type declarations.
 
 ## [0.4.0] - 2025-03-18
 

--- a/core/datatests/generators/logical_line_parser.rs
+++ b/core/datatests/generators/logical_line_parser.rs
@@ -3140,6 +3140,15 @@ mod regression {
             unterminated_param_list = "
                 _|procedure F(
             ",
+            visibility_keywords_outside_type_decl = "
+                _|const
+                _|  Strict = 0;
+                _|  Automated = 0;
+                _|  Private = 0;
+                _|  Protected = 0;
+                _|  Public = 0;
+                _|  Published = 0;
+            "
         );
     }
 }

--- a/core/src/defaults/parser/token_consolidation_tests.rs
+++ b/core/src/defaults/parser/token_consolidation_tests.rs
@@ -244,9 +244,13 @@ casing_token_consolidation_test!(
             type
               tfoo = class
               protected
+                const
+                  &PROTECTED = False;
+                var
+                  &PRIVATE: integer;
                 property PUBLIC: integer read PRIVATE stored PROTECTED;
               automated
-              end"
+              end;"
         },
     },
 );


### PR DESCRIPTION
Fixes #211.

- **Fix parsing of visibility specifiers outside type declarations**
- **Fix compiler errors in test for weird visibility consolidation cases**
    * This case was stressing a really wierd case where you can use the visibility specifiers as
      identifiers inside a type declaration, but it wasn't completely correct because it didn't
      declare the identifiers which it was referencing. I've confirmed that this example is actually
      allowed by Delphi.
