### PR TITLE
Inline `reference to procedure` and `reference to function`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Never break in the middle of `reference to function` and `reference to procedure`.
+
 ### Fixed
 
 - Fixed formatting of structures after a label.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Never break in the middle of `reference to function` and `reference to procedure`.
+- Improve consistency across procedural types and anonymous routine headers.
 
 ### Fixed
 

--- a/core/datatests/generators/optimising_line_formatter.rs
+++ b/core/datatests/generators/optimising_line_formatter.rs
@@ -1682,24 +1682,24 @@ mod type_decls {
                           ) of object;
                 ",
                 procedure_reference = "
+                    // wrap_column=40                       |
                     type
                       AA = reference to procedure;
-                      AAA =
+                      AAAAAAAAAAAAA =
                           reference to procedure;
-                      AAA =
-                          reference to
-                              procedure(AAA: BBB);
-                      AAA =
-                          reference to
-                              procedure(
-                                  AAAA: BBB
-                              );
-                      AAA =
-                          reference to
-                              procedure(
-                                  AA: B;
-                                  CC: D
-                              );
+                      AAA = reference to procedure(AA: BB);
+                      AAAAA =
+                          reference to procedure(AAA: BBB);
+                      AAAAA =
+                          reference to procedure(
+                              AAAA: BBBB
+                          );
+                ",
+                procedure_reference_no_wrap = "
+                    // wrap_column=28           |
+                    type
+                      AA =
+                          reference to procedure;
                 ",
                 simple_procedure = "
                     type
@@ -1731,17 +1731,29 @@ mod type_decls {
                           ): AAAAAA of object;
                 ",
                 function_reference = "
+                    // wrap_column=40                       |
                     type
-                      AAA = reference to function;
+                      AAA = reference to function: BBBBBBBB;
                       AAA =
-                          reference to
-                              function: BBBBBBBBB;
+                          reference to function: BBBBBBBBB;
+                      AAA = reference to function();
+                      AAA = reference to function(A: B): CC;
+                      AAAA =
+                          reference to function(A: B): CCCC;
+                      AAAA =
+                          reference to function(A: B):
+                              CCCCC;
                       AAA =
-                          reference to
-                              function(
-                                  AA: B;
-                                  CC: D
-                              ): BBBBBBB;
+                          reference to function(
+                              AA: B;
+                              CC: D
+                          ): BBBBBBB;
+                ",
+                function_reference_no_wrap = "
+                    // wrap_column=27          |
+                    type
+                      AA =
+                          reference to function;
                 ",
                 simple_function = "
                     type

--- a/core/datatests/generators/optimising_line_formatter.rs
+++ b/core/datatests/generators/optimising_line_formatter.rs
@@ -752,8 +752,9 @@ mod anonymous {
                         end
                     );
                     AAAA(
-                        function(AAAA: BBBBB):
-                            CCCC
+                        function(
+                            AAAA: BBBBB
+                        ): CCCC
                         begin
                         end
                     );
@@ -1673,8 +1674,9 @@ mod type_decls {
                       AAAAAA =
                           procedure of object;
                       AAAAAA =
-                          procedure(AA: B) of
-                              object;
+                          procedure(
+                              AA: B
+                          ) of object;
                       AAAAAA =
                           procedure(
                               AA: BB;
@@ -1722,13 +1724,20 @@ mod type_decls {
                       AAAAAA =
                           function: AAA of object;
                       AAAAAA =
-                          function(AA: B):
-                              AAAA of object;
+                          function(
+                              AA: B
+                          ): AAAA of object;
                       AAAAAA =
                           function(
                               AA: BB;
                               CC: DD
                           ): AAAAAA of object;
+                      AAAAAA =
+                          function(
+                              AA: BB;
+                              CC: DD
+                          ): AAAAAAAAAAA of
+                              object;
                 ",
                 function_reference = "
                     // wrap_column=40                       |
@@ -1741,8 +1750,9 @@ mod type_decls {
                       AAAA =
                           reference to function(A: B): CCCC;
                       AAAA =
-                          reference to function(A: B):
-                              CCCCC;
+                          reference to function(
+                              A: B
+                          ): CCCCC;
                       AAA =
                           reference to function(
                               AA: B;

--- a/core/src/rules/optimising_line_formatter/contexts.rs
+++ b/core/src/rules/optimising_line_formatter/contexts.rs
@@ -552,9 +552,6 @@ impl<'a> SpecificContextStack<'a> {
             {
                 self.update_last_matching_context(node, CT::Subject, apply_pivotal_break);
             }
-            (Some(TT::Keyword(KK::To)), Some(TT::Keyword(KK::Procedure | KK::Function))) => {
-                self.update_last_matching_context(node, CT::Subject, apply_pivotal_break);
-            }
             (Some(TT::Op(OK::Assign | OK::Equal(EqKind::Decl))), _) => {
                 let is_type_parens = self
                     .ctx_data_iter(node)

--- a/core/src/rules/optimising_line_formatter/contexts.rs
+++ b/core/src/rules/optimising_line_formatter/contexts.rs
@@ -869,14 +869,6 @@ impl<'a> LineFormattingContexts<'a> {
                             contexts.push(CT::Subject);
                             contexts.push_expression();
                         }
-                        TT::Keyword(KK::To)
-                            if matches!(
-                                next_token_type,
-                                Some(TT::Keyword(KK::Function | KK::Procedure))
-                            ) =>
-                        {
-                            contexts.push(CT::Subject);
-                        }
                         TT::Keyword(
                             KK::Function | KK::Procedure | KK::Destructor | KK::Constructor,
                         ) => {
@@ -1123,6 +1115,9 @@ impl<'a> LineFormattingContexts<'a> {
                 {
                     let op_prec = super::get_operator_precedence(op).unwrap();
                     contexts.pop_until_and_retain(CT::Precedence(op_prec));
+                }
+                TT::Keyword(KK::Of) if matches!(next_token_type, Some(TT::Keyword(KK::Object))) => {
+                    contexts.pop_until_after(CT::AnonHeader);
                 }
                 TT::Keyword(KK::Then | KK::Do | KK::Of) => {
                     contexts.pop_until(context_matches!(CT::ControlFlow | CT::ForLoop));

--- a/core/src/rules/optimising_line_formatter/requirements.rs
+++ b/core/src/rules/optimising_line_formatter/requirements.rs
@@ -99,7 +99,7 @@ impl InternalOptimisingLineFormatter<'_, '_> {
                     .unwrap_or_default()
             }
             (
-                Some(TT::Keyword(KK::Class)),
+                Some(TT::Keyword(KK::Class | KK::To)),
                 Some(TT::Keyword(KK::Function | KK::Procedure | KK::Constructor | KK::Destructor)),
             ) => DR::MustNotBreak,
             (

--- a/core/src/rules/optimising_line_formatter/requirements.rs
+++ b/core/src/rules/optimising_line_formatter/requirements.rs
@@ -261,6 +261,11 @@ impl InternalOptimisingLineFormatter<'_, '_> {
                 .map(|(ctx, _)| ctx.context_type() == CT::CommaList)
                 .if_else_or_default(DR::Indifferent, DR::MustNotBreak),
             (Some(TT::Keyword(KK::Raise | KK::At)), _) => DR::MustNotBreak,
+            (Some(TT::Keyword(KK::Of)), Some(TT::Keyword(KK::Object))) => contexts_data
+                .iter()
+                .find(|(ctx, _)| matches!(ctx.context_type(), CT::AssignRHS))
+                .map(|(_, data)| data.is_child_broken)
+                .if_else_or_default(DR::Indifferent, DR::MustNotBreak),
             (_, Some(TT::Keyword(KK::Then | KK::Do | KK::Of))) => DR::MustNotBreak,
             (Some(TT::Keyword(KK::Then | KK::Do)), Some(TT::Keyword(KK::Begin))) => contexts_data
                 .get_last_context(CT::ControlFlowBegin)


### PR DESCRIPTION
This PR fixes #206

Additionally, this PR improves consistency across all routine headings. This includes procedural types and anonymous routine headings.