### PR TITLE
Remove extraneous contexts in `type of` constructs

### DIFF
--- a/core/src/rules/optimising_line_formatter/contexts.rs
+++ b/core/src/rules/optimising_line_formatter/contexts.rs
@@ -867,7 +867,7 @@ impl<'a> LineFormattingContexts<'a> {
                             contexts.push_expression();
                         }
                         TT::Keyword(KK::Type)
-                            if !matches!(next_token_type, Some(TT::Keyword(KK::Of))) =>
+                            if !matches!(current_token_type, TT::Keyword(KK::Of)) =>
                         {
                             contexts.push(CT::Subject);
                             contexts.push_expression();


### PR DESCRIPTION
I realised the contexts around `type of` were being duplicated. This was because the filter on the next token was looking at the wrong token.
The match is based on the previous token, so the next token in this context is the current token.