### PR TITLE
Allow set of anonymous enum to be formatted more compactly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Never break in the middle of `reference to function` and `reference to procedure`.
 - Improve consistency across procedural types and anonymous routine headers.
 - Improved line wrapping layout heuristics for lines that exceed the `wrap_column`.
+- Allow `set of` anonymous enum to be on same line as `=`.
 
 ### Fixed
 

--- a/core/datatests/generators/optimising_line_formatter.rs
+++ b/core/datatests/generators/optimising_line_formatter.rs
@@ -1584,16 +1584,17 @@ mod type_decls {
                           set of (AAA);
                       AAAAAAAAAAAAA =
                           set of (AAAA, BBB, CCC);
-                      AAAAAAAAAAAAA =
-                          set of
-                              (AAAA, BBBB, CCC);
-                      AAAAAAAAAAAAA =
-                          set of
-                              (
-                                  AAAAA,
-                                  BBBBB,
-                                  CCCC
-                              );
+                      AAAAAAAAAAAAA = set of (
+                          AAAA,
+                          BBBB,
+                          CCC
+                      );
+                      AAAAAAAAAAAAAAAAAA =
+                          set of (
+                              AAAAA,
+                              BBBBB,
+                              CCCC
+                          );
                 ",
                 file = "
                     type

--- a/core/src/rules/optimising_line_formatter/contexts.rs
+++ b/core/src/rules/optimising_line_formatter/contexts.rs
@@ -552,6 +552,13 @@ impl<'a> SpecificContextStack<'a> {
             {
                 self.update_last_matching_context(node, CT::Subject, apply_pivotal_break);
             }
+            (Some(TT::Op(OK::Assign | OK::Equal(EqKind::Decl))), Some(TT::Keyword(KK::Set))) => {
+                // This is to allow `= set of (...` to break the elements of the
+                // list and not before `set`
+                self.update_last_matching_context(node, context_matches!(CT::Base), |_, data| {
+                    data.is_broken |= is_break;
+                });
+            }
             (Some(TT::Op(OK::Assign | OK::Equal(EqKind::Decl))), _) => {
                 let is_type_parens = self
                     .ctx_data_iter(node)
@@ -603,6 +610,9 @@ impl<'a> SpecificContextStack<'a> {
             (Some(TT::Keyword(KK::At)), _) => {}
             (Some(TT::Keyword(KK::Type)), Some(tt)) if tt != TT::Keyword(KK::Of) => {
                 self.update_last_matching_context(node, context_matches!(_), apply_pivotal_break);
+            }
+            (Some(TT::Keyword(KK::Of)), Some(TT::Op(OK::LParen))) => {
+                // To exclude `set of` anonymous enum, e.g.,
             }
             (Some(TT::Keyword(KK::Of)), _) => {
                 self.update_last_matching_context(node, context_matches!(_), apply_pivotal_break);

--- a/core/src/rules/optimising_line_formatter/requirements.rs
+++ b/core/src/rules/optimising_line_formatter/requirements.rs
@@ -261,11 +261,18 @@ impl InternalOptimisingLineFormatter<'_, '_> {
                 .map(|(ctx, _)| ctx.context_type() == CT::CommaList)
                 .if_else_or_default(DR::Indifferent, DR::MustNotBreak),
             (Some(TT::Keyword(KK::Raise | KK::At)), _) => DR::MustNotBreak,
+            // For `set of` anonymous enums
+            (Some(TT::Keyword(KK::Of)), Some(TT::Op(OK::LParen))) => DR::MustNotBreak,
+            // For `procedure of object` to allow wrapping `object`
             (Some(TT::Keyword(KK::Of)), Some(TT::Keyword(KK::Object))) => contexts_data
                 .iter()
                 .find(|(ctx, _)| matches!(ctx.context_type(), CT::AssignRHS))
                 .map(|(_, data)| data.is_child_broken)
                 .if_else_or_default(DR::Indifferent, DR::MustNotBreak),
+            (Some(TT::Keyword(KK::Of)), _) => contexts_data
+                .get_last_context(context_matches!(ContextType::Base))
+                .map(|(_, data)| data.is_child_broken)
+                .if_else_or(DR::Indifferent, DR::MustNotBreak, DR::Indifferent),
             (_, Some(TT::Keyword(KK::Then | KK::Do | KK::Of))) => DR::MustNotBreak,
             (Some(TT::Keyword(KK::Then | KK::Do)), Some(TT::Keyword(KK::Begin))) => contexts_data
                 .get_last_context(CT::ControlFlowBegin)


### PR DESCRIPTION
This addresses #205

When it fits, it is more natural to allow `set of` to be formatted on the same line as the type name.
E.g.,
```delphi
A = set of (
    A,
    B
);
```