### PR TITLE
Stop consuming directive-like declarations after procedural types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Visibility specifiers (e.g. `private`, `public`) are no longer treated like section headers when
   used outside type declarations.
 - Fixed formatting of comments before the first item in import and exports clauses.
+- Stopped consuming directive-like declarations following procedural types.
 
 ## [0.4.0] - 2025-03-18
 

--- a/core/datatests/generators/logical_line_parser.rs
+++ b/core/datatests/generators/logical_line_parser.rs
@@ -860,6 +860,32 @@ mod decl_sections {
                         3:Declaration
                     "
                 ),
+                proc_of_object_var_with_false_directives = (
+                    "
+                        1|var
+                        2|  A: procedure of object; near;
+                        _|  Index: AA;
+                        3|  A: function: AA of object; far;
+                        _|  Name, Virtual: AA;
+                    ",
+                    "
+                        2:Declaration
+                        3:Declaration
+                    "
+                ),
+                ref_to_proc_var_with_false_directives = (
+                    "
+                        1|var
+                        2|  A: reference to procedure; stdcall;
+                        _|  Index: AA;
+                        3|  A: reference to function: AA; safecall;
+                        _|  Name, Virtual: AA;
+                    ",
+                    "
+                        2:Declaration
+                        3:Declaration
+                    "
+                ),
                 type_class = (
                     "
                         1|type

--- a/core/src/defaults/parser.rs
+++ b/core/src/defaults/parser.rs
@@ -1395,6 +1395,14 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
                 Some(TT::Keyword(keyword_kind) | TT::IdentifierOrKeyword(keyword_kind))
                     if is_directive(&keyword_kind) && parser.paren_level == 0 =>
                 {
+                    if matches!(
+                        parser.get_token_type::<1>(),
+                        Some(TT::Op(OK::Comma | OK::Colon))
+                    ) {
+                        // The next thing is not a directive, but a declaration
+                        return OpResult::Break;
+                    }
+
                     parser.consolidate_current_keyword();
                     parser.next_token();
                     if let (KK::External, Some(KK::Name)) =


### PR DESCRIPTION
This fixes #226 