### PR TITLE
Explore conditional directive paths more efficiently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed indentation of comments around statements outside of statement lists.
+- Fixed performance issues with heavily nested conditional directives.
 
 ## [0.5.1] - 2025-06-02
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - clause of `do`/`then`/`else` structures (without `begin`-`end`)
   - after compound statement, but before the semicolon
 
+### Changed
+
+- Conditional directive parsing now uses a greedy algorithm that avoids the exponential
+  performance issues with the old algorithm.
+
 ## 0.5.1 - 2025-06-02
 
 ### Fixed

--- a/core/src/defaults/parser/directive_tree.rs
+++ b/core/src/defaults/parser/directive_tree.rs
@@ -1,0 +1,357 @@
+//! Parsing utility for conditional directives. Used for generating a series of "passes" over a slice of tokens.
+//!
+//! Use [DirectiveTree::parse] to get started.
+use std::ops::Range;
+
+use itertools::Itertools;
+
+use crate::prelude::*;
+use RawTokenType as TT;
+
+/// Represents a portion of source code as a kind of heterogeneous tree, where each "node" is either
+/// a contiguous string of tokens ("flat"), or a series of subtrees representing a complete section
+/// of conditionally-defined code ("nested").
+///
+/// As an example, consider the following code
+/// ```delphi
+/// A;             // flat section
+/// {$ifdef FOO}   // nested section
+/// B;             //  | flat section
+///   {$ifdef BAR} //  | nested section
+/// C;             //  |  | flat section
+///   {$endif}     //  |  |
+/// {$elseif FOO}  //  |
+/// D;             //  | flat section
+/// E;             //  |  |
+/// {$endif}       //  |
+/// F;             // flat section
+/// ```
+///
+/// This tree can be used to iterate simplified versions of the code (without the conditional directives).
+/// Each "pass" corresponds to a particular set of choices for each conditional directive (i.e. take
+/// branch 1 at directive 1, and branch 2 at directive 2, etc.). You can think of this as iterating
+/// "real" versions of the code that the compiler could potential see, given the right configuration.
+///
+/// Use [DirectiveTree::passes] to create an iterator for the passes.
+pub struct DirectiveTree {
+    sections: Vec<Section>,
+}
+
+enum Section {
+    Flat { explored: bool, range: Range<usize> },
+    Nested(Vec<DirectiveTree>),
+}
+
+impl DirectiveTree {
+    /// Creates a [DirectiveTree] representing the provided slice of tokens.
+    pub fn parse(tokens: &[RawToken]) -> Self {
+        let mut tokens = tokens.iter().map(RawToken::get_token_type).enumerate();
+        Self::parse_next(true, &mut tokens).0
+    }
+
+    fn parse_next(
+        top_level: bool,
+        tokens: &mut impl Iterator<Item = (usize, RawTokenType)>,
+    ) -> (Self, Option<ConditionalDirectiveKind>) {
+        let mut tree = DirectiveTree { sections: vec![] };
+        loop {
+            let (flat, cdk) = Section::parse_flat(tokens);
+            tree.sections.push(flat);
+            match cdk {
+                Some(cdk) if cdk.is_if() => {
+                    let nested = Section::parse_nested(tokens);
+                    tree.sections.push(nested);
+                }
+                // ignore any unmatched directives at the top level
+                Some(_) if top_level => {}
+                None | Some(_) => return (tree, cdk),
+            }
+        }
+    }
+}
+
+impl Section {
+    fn parse_flat(
+        tokens: &mut impl Iterator<Item = (usize, RawTokenType)>,
+    ) -> (Self, Option<ConditionalDirectiveKind>) {
+        let mut start = None;
+        let mut range = 0..0;
+        let mut ending_cdk = None;
+
+        for (idx, tt) in tokens {
+            if let TT::ConditionalDirective(cdk) = tt {
+                ending_cdk = Some(cdk);
+                break;
+            };
+            range = (*start.get_or_insert(idx))..(idx + 1);
+        }
+
+        (
+            Section::Flat {
+                explored: false,
+                range,
+            },
+            ending_cdk,
+        )
+    }
+
+    fn parse_nested(tokens: &mut impl Iterator<Item = (usize, RawTokenType)>) -> Self {
+        let (if_tree, mut cdk) = DirectiveTree::parse_next(false, tokens);
+        let mut sections = vec![if_tree];
+        while matches!(cdk, Some(cdk) if cdk.is_else()) {
+            let (tree, next) = DirectiveTree::parse_next(false, tokens);
+            sections.push(tree);
+            cdk = next;
+        }
+        Section::Nested(sections)
+    }
+}
+
+impl DirectiveTree {
+    fn explored(&self) -> bool {
+        self.sections.iter().all(|s| s.explored())
+    }
+
+    /// Creates an iterator for the conditional directive passes.
+    pub fn passes(self) -> PassIter {
+        PassIter {
+            tree: self,
+            exhausted: false,
+        }
+    }
+
+    fn pass(&mut self, pass: &mut Vec<usize>) {
+        for section in &mut self.sections {
+            section.pass(pass);
+        }
+    }
+}
+
+impl Section {
+    fn pass(&mut self, pass: &mut Vec<usize>) {
+        match self {
+            Section::Flat {
+                explored,
+                range: tokens,
+            } => {
+                pass.extend(tokens.clone());
+                *explored = true;
+            }
+            Section::Nested(sections) => {
+                if let Some(tree) = sections.iter_mut().find_or_last(|g| !g.explored()) {
+                    tree.pass(pass);
+                }
+            }
+        }
+    }
+
+    fn explored(&self) -> bool {
+        match self {
+            Section::Flat { explored, .. } => *explored,
+            Section::Nested(sections) => sections.iter().all(|s| s.explored()),
+        }
+    }
+}
+
+/// Iterates the conditional directive passes of a [DirectiveTree].
+///
+/// Each iteration yields a "pass", which is a [Vec] of global token indices included in that
+/// version of the source code.
+///
+/// The order and selection of conditional directive branch paths is implementation-defined and not
+/// guaranteed to be stable between releases.
+pub struct PassIter {
+    tree: DirectiveTree,
+    exhausted: bool,
+}
+
+impl Iterator for PassIter {
+    type Item = Vec<usize>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.exhausted {
+            return None;
+        }
+
+        let mut pass = vec![];
+        self.tree.pass(&mut pass);
+
+        self.exhausted = self.tree.explored();
+        Some(pass)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn token_indices_to_string(tokens: &[RawToken], indices: &[usize]) -> String {
+        let mut result = String::new();
+        for &index in indices {
+            if let Some(token) = tokens.get(index) {
+                result.push_str(token.get_leading_whitespace());
+                result.push_str(token.get_content());
+            }
+        }
+        result
+    }
+
+    const IF: &str = "{$ifdef}";
+    const ELSEIF: &str = "{$elseif}";
+    const ELSE: &str = "{$else}";
+    const END: &str = "{$endif}";
+
+    #[yare::parameterized(
+        no_directives = {
+            "foo(a, b, c);".to_owned(),
+            &["foo(a, b, c);"],
+        },
+        if_around_all = {
+            format!("{IF}foo(a, b, c);{END}"),
+            &["foo(a, b, c);"],
+        },
+        if_else_around_all = {
+            format!("{IF}foo(a, b, c){ELSEIF}bar(d, e, f){END}"),
+            &[
+                "foo(a, b, c)",
+                "bar(d, e, f)",
+            ],
+        },
+        if_else_else_around_all = {
+            format!("{IF}foo(a, b, c){ELSEIF}bar(d, e, f){ELSEIF}baz(g, h, i){END}"),
+            &[
+                "foo(a, b, c)",
+                "bar(d, e, f)",
+                "baz(g, h, i)",
+            ],
+        },
+        if_internal = {
+            format!("foo({IF}a{END});"),
+            &["foo(a);"],
+        },
+        if_else_internal = {
+            format!("foo({IF}a{ELSEIF}b{END});"),
+            &[
+                "foo(a);",
+                "foo(b);",
+            ],
+        },
+        if_else_else_internal = {
+            format!("foo({IF}a{ELSEIF}b{ELSEIF}c{END});"),
+            &[
+                "foo(a);",
+                "foo(b);",
+                "foo(c);",
+            ],
+        },
+        max_branch = {
+            format!("foo({IF}a{ELSEIF}b{END}, {IF}d{ELSEIF}e{ELSEIF}f{END});"),
+            &[
+                "foo(a,d);",
+                "foo(b,e);",
+                "foo(b,f);",
+            ],
+        },
+        max_branch_nested = {
+            indoc::formatdoc!("
+                foo(
+                  {IF}
+                    {IF}a{ELSEIF}b{END}, {IF}d{ELSEIF}e{ELSEIF}f{END},
+                  {END}
+                  {IF}
+                    {IF}g{ELSEIF}h{END}, {IF}i{ELSEIF}j{ELSEIF}k{END}
+                  {ELSEIF}
+                    {IF}l{ELSEIF}m{END}, {IF}n{ELSEIF}o{ELSEIF}p{END}
+                  {END});"
+            ),
+            &[
+                "foo(a,d,g,i);",
+                "foo(b,e,h,j);",
+                "foo(b,f,h,k);",
+                "foo(b,f,l,n);",
+                "foo(b,f,m,o);",
+                "foo(b,f,m,p);",
+            ],
+        },
+        manual_elseif = {
+            indoc::formatdoc!("
+                {IF}a
+                {ELSE}{IF}b
+                {ELSE}{IF}c
+                {ELSE}{IF}d
+                {ELSE}{IF}e
+                {ELSE}{IF}f
+                {ELSE}{IF}g
+                {ELSE}{IF}h
+                {ELSE}{IF}i
+                {ELSE}{IF}j
+                {ELSE}{IF}k
+                {ELSE}{IF}l
+                {ELSE}{IF}m
+                {ELSE}{IF}n
+                {ELSE}{IF}o
+                {ELSE}{IF}p
+                {ELSE}{IF}q
+                {ELSE}{IF}r
+                {ELSE}{IF}s
+                {ELSE}{IF}t
+                {ELSE}{IF}u
+                {ELSE}{IF}v
+                {ELSE}{IF}w
+                {ELSE}{IF}x
+                {ELSE}{IF}y
+                {ELSE}z
+                {END}{END}{END}{END}{END}{END}{END}{END}{END}{END}{END}{END}{END}{END}{END}{END}{END}{END}{END}{END}{END}{END}{END}{END}{END}"
+            ),
+            &[
+                "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q",
+                "r", "s", "t", "u", "v", "w", "x", "y", "z",
+            ],
+        },
+        first_branch_explored_only_once = {
+            indoc::formatdoc!("
+                {IF}
+                  {IF}
+                  {ELSE}a
+                  {END}
+                {END}
+
+                {IF}b
+                {ELSE}c
+                {END}"
+            ),
+            // Note that there is no "AB" parse; each 'flat' section is only walked once when it's not the last branch.
+            &["b", "ac"],
+        },
+        unmatched_end = {
+            indoc::formatdoc!("
+                {END}
+                {ELSE}
+
+                {IF}a
+                {ELSE}b
+                {END}
+
+                {END}
+                {ELSE}
+                {END}
+
+                {IF}c
+                {ELSE}d
+                {END}
+
+                {END}"
+            ),
+            &["ac", "bd"],
+        },
+    )]
+    fn token_views(input: String, expected_pass_strings: &[&str]) {
+        let raw_tokens = DelphiLexer {}.lex(&input);
+        let pass_strings = DirectiveTree::parse(&raw_tokens)
+            .passes()
+            .map(|pass| token_indices_to_string(&raw_tokens, &pass))
+            .collect_vec();
+        let pass_strings = pass_strings.iter().map(String::as_str).collect_vec();
+        pretty_assertions::assert_eq!(&expected_pass_strings, &pass_strings);
+    }
+}

--- a/core/src/defaults/parser/utility_tests.rs
+++ b/core/src/defaults/parser/utility_tests.rs
@@ -1,218 +1,6 @@
-use spectral::prelude::*;
-
 use super::*;
 use crate::prelude::*;
-
-#[yare::parameterized(
-    valid = {
-        indoc::indoc! {"
-            function Bar(
-            {$ifdef A}
-              {$ifdef A}
-              A
-              {$elseif}
-                {$ifdef A}
-              B
-                {$elseif}
-              C
-                {$elseif}
-              D
-                {$endif}
-              {$endif}
-            {$endif}
-            );"
-        },
-        &[0, 1, 2],
-    },
-    no_end = {
-        indoc::indoc! {"
-            function Bar(
-            {$ifdef A}
-              {$ifdef A}
-              A
-              {$elseif}
-                {$ifdef A}
-              B
-                {$elseif}
-              C
-                {$elseif}
-              D
-            );"
-        },
-        &[0, 1, 2],
-    },
-    adjacent_bigger_first = {
-        indoc::indoc! {"
-            function Bar(
-            {$ifdef A}
-              {$ifdef A}
-              A
-              {$else}
-              B
-              {$endif}
-              {$ifdef A}
-              C
-              {$endif}
-            {$endif}
-            );"
-        },
-        &[0, 1],
-    },
-    adjacent_bigger_second = {
-        indoc::indoc! {"
-            function Bar(
-            {$ifdef A}
-              {$ifdef A}
-              A
-              {$endif}
-              {$ifdef A}
-              B
-              {$else}
-              C
-              {$endif}
-            {$endif}
-            );"
-        },
-        &[0, 1],
-    },
-    no_branches = {
-        indoc::indoc! {"
-            function Bar(
-            {$ifdef A}
-              {$ifdef A}
-              A
-                {$ifdef A}
-              B
-                {$endif}
-              {$endif}
-            {$endif}
-            );"
-        },
-        &[0, 0, 0],
-    },
-    naked_else = { "function Bar({$elseif});", &[0] },
-    no_directives = { "function Bar();", &[0] },
-    no_else = { "{$ifdef}function Bar();{$endif}", &[0] },
-)]
-fn directive_level_counts(input: &str, expected_levels: &[usize]) {
-    let raw_tokens = DelphiLexer {}.lex(input);
-    let conditional_branches = get_conditional_branches_per_directive(&raw_tokens);
-    assert_that(&get_directive_level_last_indices(&conditional_branches).as_slice())
-        .is_equal_to(expected_levels);
-}
-
-mod passes {
-    use super::*;
-
-    fn token_indices_to_string(tokens: &[RawToken], indices: &[usize]) -> String {
-        let mut result = String::new();
-        for &index in indices {
-            if let Some(token) = tokens.get(index) {
-                result.push_str(token.get_leading_whitespace());
-                result.push_str(token.get_content());
-            }
-        }
-        result
-    }
-
-    const IF: &str = "{$ifdef}";
-    const ELSEIF: &str = "{$elseif}";
-    const END: &str = "{$endif}";
-
-    #[yare::parameterized(
-        no_directives = {
-            "foo(a, b, c);".to_owned(),
-            &["foo(a, b, c);"],
-        },
-        if_around_all = {
-            format!("{IF}foo(a, b, c);{END}"),
-            &["foo(a, b, c);"],
-        },
-        if_else_around_all = {
-            format!("{IF}foo(a, b, c){ELSEIF}bar(d, e, f){END}"),
-            &[
-                "foo(a, b, c)",
-                "bar(d, e, f)",
-            ],
-        },
-        if_else_else_around_all = {
-            format!("{IF}foo(a, b, c){ELSEIF}bar(d, e, f){ELSEIF}baz(g, h, i){END}"),
-            &[
-                "foo(a, b, c)",
-                "bar(d, e, f)",
-                "baz(g, h, i)",
-            ],
-        },
-        if_internal = {
-            format!("foo({IF}a{END});"),
-            &["foo(a);"],
-        },
-        if_else_internal = {
-            format!("foo({IF}a{ELSEIF}b{END});"),
-            &[
-                "foo(a);",
-                "foo(b);",
-            ],
-        },
-        if_else_else_internal = {
-            format!("foo({IF}a{ELSEIF}b{ELSEIF}c{END});"),
-            &[
-                "foo(a);",
-                "foo(b);",
-                "foo(c);",
-            ],
-        },
-        max_branch = {
-            format!("foo({IF}a{ELSEIF}b{END}, {IF}d{ELSEIF}e{ELSEIF}f{END});"),
-            &[
-                "foo(a,d);",
-                "foo(b,e);",
-                "foo(b,f);",
-            ],
-        },
-        max_branch_nested = {
-            indoc::formatdoc!("
-                foo(
-                  {IF}
-                    {IF}a{ELSEIF}b{END}, {IF}d{ELSEIF}e{ELSEIF}f{END},
-                  {END}
-                  {IF}
-                    {IF}g{ELSEIF}h{END}, {IF}i{ELSEIF}j{ELSEIF}k{END}
-                  {ELSEIF}
-                    {IF}l{ELSEIF}m{END}, {IF}n{ELSEIF}o{ELSEIF}p{END}
-                  {END});"
-            ),
-            &[
-                "foo(a,d,g,i);",
-                "foo(b,e,h,j);",
-                "foo(b,f,h,k);",
-                "foo(a,d,l,n);",
-                "foo(b,e,m,o);",
-                "foo(b,f,m,p);",
-            ],
-        },
-    )]
-    fn token_views(input: String, expected_pass_strings: &[&str]) {
-        let raw_tokens = DelphiLexer {}.lex(&input);
-        let conditional_branches = get_conditional_branches_per_directive(&raw_tokens);
-        let mut pass_tokens = Vec::new();
-        let pass_strings = get_all_conditional_branch_paths(&conditional_branches)
-            .into_iter()
-            .map(|branch| {
-                get_pass_tokens(
-                    &raw_tokens,
-                    &branch,
-                    &conditional_branches,
-                    &mut pass_tokens,
-                );
-                token_indices_to_string(&raw_tokens, &pass_tokens)
-            })
-            .collect_vec();
-        let pass_strings = pass_strings.iter().map(String::as_str).collect_vec();
-        let expected_pass_strings = expected_pass_strings.iter().collect_vec();
-        assert_that(&pass_strings).contains_all_of(&expected_pass_strings);
-    }
-}
+use pretty_assertions::assert_eq;
 
 #[yare::parameterized(
     single_ident = { "A" },
@@ -269,10 +57,10 @@ fn test_expression_parsing(input: &str, token_count: Option<usize>) {
     );
     let original_line_count = parser.current_line.len();
     parser.parse_expression();
-    assert_that(&parser.pass_index).is_equal_to(token_count);
-    assert_that(&parser.brack_level).is_equal_to(0);
-    assert_that(&parser.paren_level).is_equal_to(0);
-    assert_that(&parser.current_line.len()).is_equal_to(original_line_count);
+    assert_eq!(parser.pass_index, token_count);
+    assert_eq!(parser.brack_level, 0);
+    assert_eq!(parser.paren_level, 0);
+    assert_eq!(parser.current_line.len(), original_line_count);
 }
 
 #[test]
@@ -286,9 +74,9 @@ fn no_eof() {
     let tokens_len = tokens.len();
 
     let (lines, consolidated_tokens) = DelphiLogicalLineParser {}.parse(tokens);
-    assert_that(&lines).has_length(1);
-    assert_that(lines[0].get_tokens()).has_length(tokens_len);
-    assert_that(&tokens_len).is_equal_to(consolidated_tokens.len());
+    assert_eq!(lines.len(), 1);
+    assert_eq!(lines[0].get_tokens().len(), tokens_len);
+    assert_eq!(tokens_len, consolidated_tokens.len());
 }
 
 #[yare::parameterized(
@@ -336,5 +124,5 @@ fn run_get_token_test(pass_index: usize, offset: isize, expected_token_index: Op
         2 => parser.get_token_index::<2>(),
         _ => panic!("offset {offset} not mapped"),
     };
-    assert_that(&offset_index).is_equal_to(expected_token_index);
+    pretty_assertions::assert_eq!(offset_index, expected_token_index);
 }

--- a/core/src/rules/optimising_line_formatter/types.rs
+++ b/core/src/rules/optimising_line_formatter/types.rs
@@ -80,7 +80,7 @@ impl Decision {
 /// The decision for the first token in a line is slightly different to that of
 /// a [`Decision`].
 /// - By definition, there can't be any
-///   [`continuations`](LineWhitespace::continuation) for the first token in a
+///   [`continuations`](LineWhitespace::continuations) for the first token in a
 ///   line.
 /// - If the first decision is to be [`Decision::Continue`], the previous (or
 ///   parent) line's length needs to be known to uphold the line length limit


### PR DESCRIPTION
Fixes #52.

This introduces a new approach for exploring the directive paths. This
new method involves repeatedly "passing" over the tree of conditional
directives, greedily taking the first non-exhausted branch at every
option (or the last if all are exhausted).

This approach is linear in the number of passes required, with respect
to the max conditional nesting level. The previous approach was
exponential.

This is a change in behaviour though; the resulting paths explored can
be different, which does result in a change in formatting for some code.
However, I've not yet seen a case where the formatting has changed from
something completely unbroken to something broken. Generally speaking,
for these cases that are right at the edge of what we can handle, the
formatting was and still is broken in some way.

Here's an example of something I've noticed in some libraries
```delphi
{$IFDEF CPU32}
procedure Foo;
{$ENDIF}
{$IFDEF CPU64}
procedure _Foo;
{$ENDIF}
begin
end;

procedure Bar;
begin
end;
```

This is hard to parse as a formatter because we would need to know that
the `CPU32` and `CPU64` branches are mutually exclusive. If we don't
know that, then there will be a pass of the file that looks like this
```delphi
procedure Foo;
  procedure _Foo;
  begin
  end;

  procedure Bar;
  begin
  end;
```

Where `_Foo` and `Bar` are subprocedures of `Foo`.

There are many other examples like that where the only way to correctly
parse the file is to understand the relationships between the
conditional directive branches.
