### PR TITLE
Fix instance of new clippy lint 'double_ended_iterator_last'

### DIFF
--- a/core/src/lang.rs
+++ b/core/src/lang.rs
@@ -513,7 +513,7 @@ impl From<(&str, bool)> for FormattingData {
         // another line.
         let last_line = leading_whitespace
             .split('\n')
-            .last()
+            .next_back()
             .map(|line| line.trim_end_matches('\r'))
             .unwrap_or_default();
 

--- a/front-end/benches/benchmark_submodules.rs
+++ b/front-end/benches/benchmark_submodules.rs
@@ -93,7 +93,7 @@ fn clone_repo(url: &str, sha: &str) {
     eprintln!("Cloning {url} ({sha})");
     let clone_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("benches/clones")
-        .join(url.split('/').last().expect("URL should contain '/'"));
+        .join(url.split('/').next_back().expect("URL should contain '/'"));
     execute_command(Command::new("git").arg("init").arg(&clone_dir));
 
     if Command::new("git")


### PR DESCRIPTION
This is a common review comment of mine, so it's nice to see it become a
default clippy lint!

This issue is blocking #233.
