### PR TITLE
Fix indentation in initialization/finalization sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed formatting of `resourcestring` sections.
+- Fixed indentation inside `initialization`/`finalization` sections.
 
 ## [0.5.0] - 2025-03-31
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed parsing of `threadvar` sections in anonymous procedures.
   This technically isn't valid code, but we allow the `threadvar` section in a regular routine, so
   we should also allow it in an anonymous routine, for consistency.
+- Fixed indentation inside `initialization`/`finalization` sections. Cases include:
+  - Comments preceding the `finalization` keyword or the final `end`.
+  - Comments preceding a structured statement.
+  - Statements following a structured statement without a begin-end block.
 
 ### Added
 

--- a/core/datatests/generators/logical_line_parser.rs
+++ b/core/datatests/generators/logical_line_parser.rs
@@ -401,6 +401,28 @@ mod comments {
                         ",
                         $comment
                     ),
+                    after_initialization_finalization = format!(
+                        "
+                            _|initialization
+                            _|  {0}
+                            _|finalization
+                            _|  {0}
+                        ",
+                        $comment
+                    ),
+                    after_initialization_finalization_before_child_line = format!(
+                        "
+                            _  |initialization
+                            _  |  {0}
+                            _1 |  if Foo then{{1}}
+                            _^1|    Bar;
+                            _  |finalization
+                            _  |  {0}
+                            _2 |  if Foo then{{2}}
+                            _^2|    Bar;
+                        ",
+                        $comment
+                    ),
                 );
             };
         }
@@ -506,6 +528,13 @@ mod child_lines {
                 _^3|    BBB;
                 3  |  end);
                 1  |end);
+            ",
+            inside_initialization = "
+                _  |initialization
+                _1 |  for var I := 0 to 10 do{1}
+                _^1|    Foo;
+                _2 |  for var I := 0 to 10 do{2}
+                _^2|    Bar;
             ",
         );
     }

--- a/core/src/defaults/parser.rs
+++ b/core/src/defaults/parser.rs
@@ -330,23 +330,32 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
                     self.finish_logical_line();
                     self.next_token();
                     self.finish_logical_line();
-                    let mut push_section_context = |context_type, level_delta| {
-                        self.parse_block(ParserContext {
+                    let mut push_section_context = |context_type, level_delta, stmt_kind| {
+                        let ctx = ParserContext {
                             context_type,
                             context_ending_predicate: CEP::Opaque(section_headings),
                             level: ParserContextLevel::Level(level_delta),
-                        });
+                        };
+                        if let Some(stmt_kind) = stmt_kind {
+                            self.parse_statement_block_with_kind(ctx, stmt_kind);
+                        } else {
+                            self.parse_block(ctx);
+                        }
                     };
                     match keyword_kind {
-                        KK::Interface => push_section_context(ContextType::Interface, 0),
-                        KK::Implementation => push_section_context(ContextType::Implementation, 0),
+                        KK::Interface => push_section_context(ContextType::Interface, 0, None),
+                        KK::Implementation => {
+                            push_section_context(ContextType::Implementation, 0, None)
+                        }
                         KK::Initialization => push_section_context(
                             ContextType::StatementBlock(BlockKind::Initialization),
                             1,
+                            Some(StatementKind::Normal),
                         ),
                         KK::Finalization => push_section_context(
                             ContextType::StatementBlock(BlockKind::Finalization),
                             1,
+                            Some(StatementKind::Normal),
                         ),
                         _ => {}
                     };


### PR DESCRIPTION
The sections were not being classified as statement lists by the parser, which threw the comment handling and the child line parsing code off.

Fixes #250
