### PR TITLE
Fix comment indentation outside statement lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed indentation of comments around statements outside of statement lists.
+
 ## [0.5.1] - 2025-06-02
 
 ### Fixed

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed indentation of comments around statements outside of statement lists. Cases include:
+  - before case arm
+  - after case arm (without `begin`-`end`)
+  - clause of `do`/`then`/`else` structures (without `begin`-`end`)
+  - after compound statement, but before the semicolon
+
 ## 0.5.1 - 2025-06-02
 
 ### Fixed

--- a/core/datatests/generators/logical_line_parser.rs
+++ b/core/datatests/generators/logical_line_parser.rs
@@ -423,6 +423,55 @@ mod comments {
                         ",
                         $comment
                     ),
+                    variant_record_before_child_line = format!(
+                        "
+                            _  |A = record
+                            _  |case B of
+                            _  |{}
+                            _1 |  C: ({{1}}
+                            _^1|    D
+                            _1 |  );
+                            _  |end;
+                        ",
+                        $comment
+                    ),
+                    in_empty_compound_statement = format!(
+                        "
+                            _  |begin
+
+                            1  |  while True do{{1}}
+                            _^1|      {0}\n;
+
+                            2  |  if True then{{2}}
+                            _^2|    F
+                            2  |  else{{3}}
+                            _^3|      {0}
+                            _^3|      {0}
+                            _^3|      {0}\n;
+
+                            3  |  if True then{{3}}
+                            _^3|      {0}\n;
+
+                            _  |  case A of
+                            _4 |    B:{{4}}
+                            _^4|        {0}\n;
+                            _  |  end;
+
+                            _  |end;
+                        ",
+                        $comment
+                    ),
+                    between_compound_statement_and_semicolon = format!(
+                        "
+                            _  |begin
+                            _1 |  if True then{{1}}
+                            _^1|    begin
+                            _^1|    end
+                            _^1|      {0}\n;
+                            _  |end;
+                        ",
+                        $comment
+                    ),
                 );
             };
         }

--- a/core/datatests/generators/logical_line_parser.rs
+++ b/core/datatests/generators/logical_line_parser.rs
@@ -427,7 +427,7 @@ mod comments {
                         "
                             _  |A = record
                             _  |case B of
-                            _  |{}
+                            _  |  {}
                             _1 |  C: ({{1}}
                             _^1|    D
                             _1 |  );
@@ -440,21 +440,21 @@ mod comments {
                             _  |begin
 
                             1  |  while True do{{1}}
-                            _^1|      {0}\n;
+                            _^1|    {0}\n;
 
                             2  |  if True then{{2}}
                             _^2|    F
                             2  |  else{{3}}
-                            _^3|      {0}
-                            _^3|      {0}
-                            _^3|      {0}\n;
+                            _^3|    {0}
+                            _^3|    {0}
+                            _^3|    {0}\n;
 
                             3  |  if True then{{3}}
-                            _^3|      {0}\n;
+                            _^3|    {0}\n;
 
                             _  |  case A of
                             _4 |    B:{{4}}
-                            _^4|        {0}\n;
+                            _^4|      {0}\n;
                             _  |  end;
 
                             _  |end;
@@ -467,7 +467,7 @@ mod comments {
                             _1 |  if True then{{1}}
                             _^1|    begin
                             _^1|    end
-                            _^1|      {0}\n;
+                            _^1|    {0}\n;
                             _  |end;
                         ",
                         $comment

--- a/core/src/defaults/parser.rs
+++ b/core/src/defaults/parser.rs
@@ -280,7 +280,7 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
                         end;
                         ```
                     */
-                    if self.is_in_statement_list() {
+                    if self.is_in_statement() {
                         self.finish_logical_line();
                     } else {
                         self.make_unfinished_line();
@@ -1186,11 +1186,9 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
         self.parse_statement();
         self.context.pop();
     }
-    fn is_in_statement_list(&self) -> bool {
+    fn is_in_statement(&self) -> bool {
         let mut contexts = self.context.contexts.iter().rev().map(|c| c.context_type);
-
         matches!(contexts.next(), Some(ContextType::Statement(_)))
-            && matches!(contexts.next(), Some(ContextType::StatementBlock(_)))
     }
     fn parse_statement_list_block(&mut self, context: ParserContext) {
         self.parse_statement_block_with_kind(context, StatementKind::Normal);


### PR DESCRIPTION
In cases of comments in place of statements (but not directly in statement *lists*), the parser would classify the comment as "unfinished", which means that the level would be set to the level of the next completed line.

This was mostly designed to detect comments that were at the top-level, i.e. inside a type declaration, or before a routine declaration. It should not be detecting comments that are merely in place of a statement.

Fixes #222 (and some related issues I discovered along the way).