### PR TITLE
Wrap anonymous routines when they contain any sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Anonymous routines are now wrapped onto multiple lines whenever they contain sections
+  (e.g. `var`, `const`, `type`).
+
 ## [0.5.1] - 2025-06-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix indentation for anonymous routine sections following a `type` section.
+
 ### Changed
 
 - Anonymous routines are now wrapped onto multiple lines whenever they contain sections

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Anonymous routines are now wrapped onto multiple lines whenever they contain sections
+  (e.g. `var`, `const`, `type`).
+
 ## 0.5.1 - 2025-06-02
 
 ### Fixed

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix indentation for anonymous routine sections following a `type` section.
+
 ### Changed
 
 - Anonymous routines are now wrapped onto multiple lines whenever they contain sections

--- a/core/datatests/generators/optimising_line_formatter.rs
+++ b/core/datatests/generators/optimising_line_formatter.rs
@@ -853,14 +853,53 @@ mod anonymous {
             ",
             with_sections = "
                     // wrap_column=100
+                    A :=
+                        function
+                        label
+                          B;
+                        begin
+                        end;
+                    A :=
+                        function
+                        const
+                          B = '';
+                        begin
+                        end;
+                    A :=
+                        function
+                        type
+                          C = D;
+                        begin
+                        end;
+                    A :=
+                        function
+                        var
+                          B: C;
+                        begin
+                        end;
+                    A :=
+                        function
+                        threadvar
+                          B: C;
+                        begin
+                        end;
 
-                    A := function label B; begin end;
-                    A := function const B = ''; begin end;
-                    A := function type C = D; begin end;
-                    A := function var B: C; begin end;
-                    A := function threadvar B: C; begin end;
+                    A :=
+                        function
+                        label
+                          B;
+                        const
+                          C = '';
+                        type
+                          D = E;
+                            var
+                              F: G;
+                            threadvar
+                              H: I;
+                            begin
+                            end;
 
-                    A := function label B; const C = ''; type D = E; var F: G; threadvar H: I; begin end;
+
             "
         );
     }

--- a/core/datatests/generators/optimising_line_formatter.rs
+++ b/core/datatests/generators/optimising_line_formatter.rs
@@ -850,6 +850,17 @@ mod anonymous {
                         begin
                           A;
                         end;
+            ",
+            with_sections = "
+                    // wrap_column=100
+
+                    A := function label B; begin end;
+                    A := function const B = ''; begin end;
+                    A := function type C = D; begin end;
+                    A := function var B: C; begin end;
+                    A := function threadvar B: C; begin end;
+
+                    A := function label B; const C = ''; type D = E; var F: G; threadvar H: I; begin end;
             "
         );
     }

--- a/core/datatests/generators/optimising_line_formatter.rs
+++ b/core/datatests/generators/optimising_line_formatter.rs
@@ -892,12 +892,12 @@ mod anonymous {
                           C = '';
                         type
                           D = E;
-                            var
-                              F: G;
-                            threadvar
-                              H: I;
-                            begin
-                            end;
+                        var
+                          F: G;
+                        threadvar
+                          H: I;
+                        begin
+                        end;
 
 
             "

--- a/core/src/rules/optimising_line_formatter/mod.rs
+++ b/core/src/rules/optimising_line_formatter/mod.rs
@@ -730,7 +730,12 @@ impl<'this> InternalOptimisingLineFormatter<'this, '_> {
 
         let starting_options = match self.get_token_type(global_token_index) {
             Some(TT::Keyword(
-                KK::Label | KK::Const(_) | KK::Type | KK::Var(_) | KK::ThreadVar | KK::Begin,
+                keyword @ (KK::Label
+                | KK::Const(_)
+                | KK::Type
+                | KK::Var(_)
+                | KK::ThreadVar
+                | KK::Begin),
             )) => {
                 // Anonymous procedure sections
                 match (
@@ -740,9 +745,10 @@ impl<'this> InternalOptimisingLineFormatter<'this, '_> {
                         ))
                         .and_then(|(_, data)| data.break_anonymous_routine),
                     line_children.descendant_count,
+                    keyword,
                 ) {
-                    (Some(false), ..=1) => Potentials::One(ChildLineOption::ContinueAll),
-                    (Some(false), _) => Potentials::None,
+                    (Some(false), ..=1, KK::Begin) => Potentials::One(ChildLineOption::ContinueAll),
+                    (Some(false), ..) => Potentials::None,
                     _ => Potentials::One(ChildLineOption::BreakAll(child_starting_ws)),
                 }
             }


### PR DESCRIPTION
This is related to #241, but doesn't exactly address the issue there.

When thinking about that issue, I realised that it's probably a bad idea to try to format anonymous routines with sections inline in the first place. In making that change, I found and fixed a bug specifically with `type` sections in anonymous routines.