### PR TITLE
Fix typo in optimising_line_formatter module doc comment

### DIFF
--- a/core/src/rules/optimising_line_formatter/mod.rs
+++ b/core/src/rules/optimising_line_formatter/mod.rs
@@ -1,4 +1,4 @@
-//! This module's soul purpose is to reflow [`LogicalLine`]s within the bounds
+//! This module's sole purpose is to reflow [`LogicalLine`]s within the bounds
 //! (where possible) of the line length limit.
 //!
 


### PR DESCRIPTION
It's not quite advanced enough to have a soul.
