### PR TITLE
Add simple integration test to cover trace logging

### DIFF
--- a/front-end/tests/logging.rs
+++ b/front-end/tests/logging.rs
@@ -1,0 +1,41 @@
+use assert_fs::{prelude::*, TempDir};
+use predicates::prelude::*;
+
+use crate::utils::*;
+
+/// The trace logging done by the [pasfmt_core::rules::optimising_line_formatter]
+/// is quite complex, and has the potential to crash due to a bug.
+///
+/// While not covering all cases, this test will ensure that the basic
+/// functionality of the logging works without crashing.
+#[test]
+fn trace_logging_does_not_crash() -> TestResult {
+    let tmp = TempDir::new()?;
+
+    let file = tmp.child("a.pas");
+    file.write_str(
+        "
+if True then
+  Foo;
+
+A :=
+    procedure
+    begin
+      var B :=
+          procedure
+          begin
+            Foo;
+          end;
+    end;
+",
+    )?;
+
+    pasfmt()?
+        .arg("--log-level=TRACE")
+        .arg(&*file)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("TRACE"));
+
+    Ok(())
+}

--- a/front-end/tests/tests.rs
+++ b/front-end/tests/tests.rs
@@ -8,4 +8,5 @@ mod help;
 #[cfg(windows)]
 mod idempotence;
 mod io_error;
+mod logging;
 mod modes;

--- a/front-end/tests/utils.rs
+++ b/front-end/tests/utils.rs
@@ -9,11 +9,7 @@ pub fn pasfmt() -> Result<assert_cmd::Command, assert_cmd::cargo::CargoError> {
 pub fn fmt(
     arg: impl AsRef<std::ffi::OsStr>,
 ) -> Result<assert_cmd::assert::Assert, assert_cmd::cargo::CargoError> {
-    Ok(pasfmt()?
-        .current_dir(TESTS_DIR)
-        .arg("--log-level=DEBUG")
-        .arg(arg)
-        .assert())
+    Ok(pasfmt()?.arg("--log-level=DEBUG").arg(arg).assert())
 }
 
 pub type DynResult<T> = Result<T, Box<dyn std::error::Error>>;


### PR DESCRIPTION
In the past we've had bugs that only exist in the trace logging generated by the optimising_line_formatter::debug submodule. It's a good idea to have at least some test coverage over this stuff.

This test asserts (almost) nothing about the exact output of the logging, which is fine. We just want to make sure it doesn't crash.
