### PR TITLE
Restructure child lines for anonymous routine sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - A break will be inserted before each multiline string to ensure stylistic consistency.
   - Surrounding code will be appropriately wrapped.
   - String contents currently can _not_ be re-indented. Including the closing quotes.
+- Anonymous routines are now wrapped onto multiple lines whenever they contain declaration sections
+  (e.g. `var`, `const`, `type`).
 
 ## [0.5.1] - 2025-06-02
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -30,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unterminated string literals will never mangle other tokens by always breaking after.
 - Improved support for multiline strings. They will now always break before, and
   break surrounding contexts.
+- Anonymous routine declaration section headers are now parsed as child lines of the
+  procedure/function keyword for the anonymous routine (previously in the parent line), and the
+  lines within sections are also parsed as child lines of the procedure/function keyword (previously
+  the parent was the section header). A side-effect of this is the force line-wrapping of anonymous
+  routines that contain any sections.
 
 ## 0.5.1 - 2025-06-02
 

--- a/core/datatests/generators/logical_line_parser.rs
+++ b/core/datatests/generators/logical_line_parser.rs
@@ -597,18 +597,18 @@ mod child_lines {
             ",
             anon_routine_with_subroutine_surrounded_by_sections = "
                 _1   |Foo(procedure{1}
-                _1   |var{2}
-                _2^2 |  V: V;
-                _3^1 |  procedure A;
-                _4^1 |  var
-                _5^1 |    V2: V2;
-                _6^1 |  begin
-                _7^1 |    P;
-                _8^1 |  end;
-                _1   |var{4}
-                _9^4 |  V3: V3;
-                _1   |begin{5}
-                _10^5|  P2;
+                _2^1 |var
+                _3^1 |  V: V;
+                _4^1 |  procedure A;
+                _5^1 |  var
+                _6^1 |    V2: V2;
+                _7^1 |  begin
+                _8^1 |    P;
+                _9^1 |  end;
+                _10^1|var
+                _11^1|  V3: V3;
+                _1   |begin{2}
+                _12^2|  P2;
                 _1   |end);
             "
         );
@@ -1099,9 +1099,9 @@ mod decl_sections {
         fn test_case(decl_section: &str, line_types: &str) -> String {
             format!(
                 "
-                    _1|A := procedure Foo
+                    _999|A := procedure{{1}} Foo
                     {}
-                    1|begin end;
+                    999|begin end;
                     ---
                     {}
                 ",
@@ -1114,7 +1114,7 @@ mod decl_sections {
                 root_dir,
                 one_label = test_case(
                     "
-                        1  |label{1}
+                        1^1|label
                         2^1|  1;
                     ",
                     "
@@ -1123,7 +1123,7 @@ mod decl_sections {
                 ),
                 many_labels = test_case(
                     "
-                        1  |label{1}
+                        1^1|label
                         2^1|  1,ident;
                     ",
                     "
@@ -1132,7 +1132,7 @@ mod decl_sections {
                 ),
                 one_const = test_case(
                     "
-                        1  |const{1}
+                        1^1|const
                         2^1|  CFoo = 1;
                     ",
                     "
@@ -1141,7 +1141,7 @@ mod decl_sections {
                 ),
                 many_consts = test_case(
                     "
-                        1  |const{1}
+                        1^1|const
                         2^1|  CFoo = 1;
                         3^1|  CBar = '1234';
                     ",
@@ -1152,7 +1152,7 @@ mod decl_sections {
                 ),
                 one_resourcestring = test_case(
                     "
-                        1  |resourcestring{1}
+                        1^1|resourcestring
                         2^1|  CFoo = 1;
                     ",
                     "
@@ -1161,7 +1161,7 @@ mod decl_sections {
                 ),
                 many_resourcestrings = test_case(
                     "
-                        1  |resourcestring{1}
+                        1^1|resourcestring
                         2^1|  CFoo = 1;
                         3^1|  CBar = '1234';
                     ",
@@ -1172,7 +1172,7 @@ mod decl_sections {
                 ),
                 one_var = test_case(
                     "
-                        1  |var{1}
+                        1^1|var
                         2^1|  A: TFoo;
                     ",
                     "
@@ -1181,7 +1181,7 @@ mod decl_sections {
                 ),
                 many_vars = test_case(
                     "
-                        1  |var{1}
+                        1^1|var
                         2^1|  A: TFoo;
                         3^1|  B: TFoo;
                     ",
@@ -1192,7 +1192,7 @@ mod decl_sections {
                 ),
                 many_names_var = test_case(
                     "
-                        1  |var{1}
+                        1^1|var
                         2^1|  A, B: TFoo;
                     ",
                     "
@@ -1201,7 +1201,7 @@ mod decl_sections {
                 ),
                 many_names_vars = test_case(
                     "
-                        1  |var{1}
+                        1^1|var
                         2^1|  A, B: TFoo;
                         3^1|  C, D: TFoo;
                     ",
@@ -1212,7 +1212,7 @@ mod decl_sections {
                 ),
                 one_threadvar = test_case(
                     "
-                        1  |threadvar{1}
+                        1^1|threadvar
                         2^1|  A: TFoo;
                     ",
                     "
@@ -1221,7 +1221,7 @@ mod decl_sections {
                 ),
                 many_threadvars = test_case(
                     "
-                        1  |threadvar{1}
+                        1^1|threadvar
                         2^1|  A: TFoo;
                         3^1|  B: TFoo;
                     ",
@@ -1231,45 +1231,45 @@ mod decl_sections {
                     "
                 ),
                 anonymous_argument = "
-                    _1 |Bar(procedure
-                    1  |label{1}
-                    2^1|  1,ident;
-                    1  |const{2}
-                    3^2|  CFoo = 1;
-                    4^2|  CBar = '1234';
-                    1  |var{3}
-                    5^3|  A, B: TFoo;
-                    6^3|  C, D: TFoo;
+                    _1 |Bar(procedure{1}
+                    2^1|label
+                    3^1|  1,ident;
+                    4^1|const
+                    5^1|  CFoo = 1;
+                    6^1|  CBar = '1234';
+                    7^1|var
+                    8^1|  A, B: TFoo;
+                    9^1|  C, D: TFoo;
                     1  |begin end);
                     ---
-                    2:Declaration
                     3:Declaration
-                    4:Declaration
                     5:Declaration
                     6:Declaration
+                    8:Declaration
+                    9:Declaration
                 ",
                 stacked = test_case(
                     "
-                        1  |label{1}
-                        2^1|  A;
-                        1  |const{2}
-                        3^2|  A = '';
-                        1  |resourcestring{3}
-                        4^3|  A = '';
-                        1  |type{4}
-                        5^4|  A = B;
-                        1  |var{5}
-                        6^5|  A: B;
-                        1  |threadvar{6}
-                        7^6|  A: B;
+                        1^1 |label
+                        2^1 |  A;
+                        3^1 |const
+                        4^1 |  A = '';
+                        5^1 |resourcestring
+                        6^1 |  A = '';
+                        7^1 |type
+                        8^1 |  A = B;
+                        9^1 |var
+                        10^1|  A: B;
+                        11^1|threadvar
+                        12^1|  A: B;
                     ",
                     "
                         2:Declaration
-                        3:Declaration
                         4:Declaration
-                        5:Declaration
                         6:Declaration
-                        7:Declaration
+                        8:Declaration
+                        10:Declaration
+                        12:Declaration
                     "
                 ),
             );
@@ -1468,8 +1468,8 @@ mod type_decls {
                         _|  end;
                     ",
                     anonymous_local = "
-                        _1 |A := procedure
-                        _1 |type{1}
+                        _1 |A := procedure{1}
+                        _^1|type
                         _^1|  TFoo = class
                         _^1|  end;
                     ",
@@ -1519,13 +1519,13 @@ mod type_decls {
                     ),
                     anonymous = format!(
                         "
-                            _1 |A := procedure Foo
-                            1  |type{{1}}
-                            2^1|  {};
+                            _1 |A := procedure{{1}} Foo
+                            2^1|type
+                            3^1|  {};
                             1  |begin
                             1  |end;
                             ---
-                            2:Declaration
+                            3:Declaration
                         ",
                         $input,
                     ),

--- a/core/datatests/generators/logical_line_parser.rs
+++ b/core/datatests/generators/logical_line_parser.rs
@@ -3411,6 +3411,21 @@ mod semicolons {
                 _^1|  Foo{}
                 1  |end;
             ",
+            after_begin = "
+                _|begin{}
+                _|end;
+            ",
+            after_try_except = "
+                _|try{0}
+                _|except{0}
+                _|else{0}
+                _|end;
+            ",
+            after_try_finally = "
+                _|try{0}
+                _|finally{0}
+                _|end;
+            ",
         );
     }
 }

--- a/core/datatests/generators/optimising_line_formatter.rs
+++ b/core/datatests/generators/optimising_line_formatter.rs
@@ -788,10 +788,18 @@ mod anonymous {
                     );
             ",
             empty_blocks = "
-                    aaa(procedure var begin end);
+                    aaa(
+                        procedure
+                        var
+                        begin
+                        end
+                    );
                     begin
                       aaa(
-                          procedure var begin end
+                          procedure
+                          var
+                          begin
+                          end
                       );
                       begin
                         aaa(
@@ -802,11 +810,24 @@ mod anonymous {
                         );
                       end;
                     end;
-                    aa(procedure const begin end);
-                    aaa(procedure type begin end);
+                    aa(
+                        procedure
+                        const
+                        begin
+                        end
+                    );
+                    aaa(
+                        procedure
+                        type
+                        begin
+                        end
+                    );
 
                     aaa(
-                        procedure const begin end
+                        procedure
+                        const
+                        begin
+                        end
                     );
                     aaa(
                         procedure
@@ -817,7 +838,10 @@ mod anonymous {
                     );
 
                     aaaa(
-                        procedure type begin end
+                        procedure
+                        type
+                        begin
+                        end
                     );
                     aaaa(
                         procedure
@@ -1014,6 +1038,54 @@ mod anonymous {
                           A;
                         end;
             ",
+            with_sections = "
+                    // wrap_column=100
+                    A :=
+                        function
+                        label
+                          B;
+                        begin
+                        end;
+                    A :=
+                        function
+                        const
+                          B = '';
+                        begin
+                        end;
+                    A :=
+                        function
+                        type
+                          C = D;
+                        begin
+                        end;
+                    A :=
+                        function
+                        var
+                          B: C;
+                        begin
+                        end;
+                    A :=
+                        function
+                        threadvar
+                          B: C;
+                        begin
+                        end;
+
+                    A :=
+                        function
+                        label
+                          B;
+                        const
+                          C = '';
+                        type
+                          D = E;
+                        var
+                          F: G;
+                        threadvar
+                          H: I;
+                        begin
+                        end;
+            "
         );
     }
 }

--- a/core/datatests/tests/suites/logical_line_parser.rs
+++ b/core/datatests/tests/suites/logical_line_parser.rs
@@ -516,7 +516,7 @@ fn parse_line(
             let &(parent_indentation, _) = parsed_lines
                 .get(&LN::Explicit(line_parent.line_index))
                 .ok_or(TestParsingError::InvalidParentReference(parent_marker))?;
-            level -= parent_indentation + 1;
+            level -= parent_indentation;
             Some(line_parent)
         } else {
             None

--- a/core/src/rules/optimising_line_formatter/contexts.rs
+++ b/core/src/rules/optimising_line_formatter/contexts.rs
@@ -625,22 +625,6 @@ impl<'a> SpecificContextStack<'a> {
             (Some(TT::Keyword(KK::Of)), _) => {
                 self.update_last_matching_context(node, context_matches!(_), apply_pivotal_break);
             }
-            (
-                _,
-                Some(TT::Keyword(KK::Label | KK::Const(_) | KK::Type | KK::Var(_) | KK::ThreadVar)),
-            ) => {
-                let _ = self.update_last_matching_context(
-                    node,
-                    context_matches!(CT::CommaElem | CT::AssignRHS),
-                    |_, data| {
-                        data.break_anonymous_routine.get_or_insert(is_break);
-                    },
-                ) || (self.formatting_contexts.line.get_line_type() != LLT::ForLoop
-                    && self.update_last_matching_context(node, CT::Subject, apply_pivotal_break))
-                    || self.update_last_matching_context(node, context_matches!(_), |_, data| {
-                        data.is_broken |= is_break;
-                    });
-            }
             (Some(TT::Keyword(KK::Uses | KK::Contains | KK::Requires | KK::Exports)), _) => {
                 self.update_last_matching_context(node, CT::Base, apply_pivotal_break);
             }
@@ -1145,15 +1129,6 @@ impl<'a> LineFormattingContexts<'a> {
                     if last_context_type != CT::RoutineHeader =>
                 {
                     contexts.push(CT::AnonHeader);
-                }
-                TT::Keyword(
-                    KK::Label
-                    | KK::Const(DeclKind::AnonSection | DeclKind::Other | DeclKind::Section)
-                    | KK::Type
-                    | KK::Var(DeclKind::AnonSection | DeclKind::Other | DeclKind::Section)
-                    | KK::ThreadVar,
-                ) => {
-                    contexts.pop_until_after(CT::AnonHeader);
                 }
                 TT::Keyword(KK::Begin) => {
                     if contexts.pop_until(CT::CommaElem) == Some(last_context_type) {

--- a/core/src/rules/optimising_line_formatter/mod.rs
+++ b/core/src/rules/optimising_line_formatter/mod.rs
@@ -865,17 +865,8 @@ impl<'this> InternalOptimisingLineFormatter<'this, '_> {
         let parent_token_type = self.get_token_type(line_children.parent_token);
         trace!("Finding child line starting options from parent {parent_token_type:?}");
         let starting_options = match parent_token_type {
-            Some(TT::Keyword(
-                KK::Label
-                | KK::Const(_)
-                | KK::Type
-                | KK::Var(_)
-                | KK::ThreadVar
-                | KK::Begin
-                | KK::Procedure
-                | KK::Function,
-            )) => {
-                // Anonymous procedure sections
+            Some(TT::Keyword(KK::Begin | KK::Procedure | KK::Function)) => {
+                // Anonymous routine subroutines and body.
                 match (
                     parent_contexts
                         .get_last_context(context_matches!(

--- a/core/src/rules/optimising_line_formatter/mod.rs
+++ b/core/src/rules/optimising_line_formatter/mod.rs
@@ -864,12 +864,7 @@ impl<'this> InternalOptimisingLineFormatter<'this, '_> {
                 }
             }
             Some(TT::Keyword(KK::Else)) => {
-                match (
-                    parent_contexts
-                        .get_last_context(context_matches!(ContextType::ControlFlowBegin))
-                        .map(|(_, data)| data.is_broken | data.is_child_broken),
-                    get_first_child_token(),
-                ) {
+                match get_first_child_token() {
                     // We never want to unwrap an `else`, e.g., `if ... then ... else ...;`
                     /*
                         if ... then
@@ -877,7 +872,7 @@ impl<'this> InternalOptimisingLineFormatter<'this, '_> {
                         else if ... then
                           ...
                     */
-                    (_, Some(TT::Keyword(KK::If))) => {
+                    Some(TT::Keyword(KK::If)) => {
                         if must_break_first_child {
                             Potentials::One(ChildLineOption::BreakAll(parent_indented_ws))
                         } else {
@@ -891,7 +886,7 @@ impl<'this> InternalOptimisingLineFormatter<'this, '_> {
                           ...
                         end
                     */
-                    (_, Some(TT::Keyword(KK::Begin))) => {
+                    Some(TT::Keyword(KK::Begin)) => {
                         if self.settings.break_before_begin || must_break_first_child {
                             Potentials::One(ChildLineOption::BreakAll(parent_base_ws))
                         } else {

--- a/core/src/rules/optimising_line_formatter/requirements.rs
+++ b/core/src/rules/optimising_line_formatter/requirements.rs
@@ -279,17 +279,7 @@ impl InternalOptimisingLineFormatter<'_, '_> {
                 .map(|(_, data)| data.is_child_broken)
                 .if_else_or_default(DR::MustBreak, DR::Indifferent),
             (_, Some(TT::Keyword(KK::Else))) => DR::MustBreak,
-            (
-                Some(_),
-                Some(TT::Keyword(
-                    KK::Label
-                    | KK::Const(DeclKind::AnonSection)
-                    | KK::Type
-                    | KK::Var(DeclKind::AnonSection)
-                    | KK::ThreadVar
-                    | KK::Begin,
-                )),
-            ) => contexts_data
+            (Some(_), Some(TT::Keyword(KK::Begin))) => contexts_data
                 .get_last_context(context_matches!(CT::CommaElem | CT::AssignRHS))
                 .and_then(|(_, data)| data.break_anonymous_routine)
                 .if_else_or_default(DR::MustBreak, DR::MustNotBreak),


### PR DESCRIPTION
- **Remove dead code in optimising_line_formatter**
- **Parse child lines with no implicit level increment**
- **Convert anonymous routine section headers to child lines**
- **Ensure starting continuation is correctly set for child lines**
- **Remove redundant code after child line restructure**

Fixes #241, and supersedes #254. 

