### PR TITLE
Migrate to Rust 2024 edition

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pasfmt-core"
 version = "0.7.0+dev"
-edition = "2021"
+edition = "2024"
 
 [features]
 _lang_types_from_str  = ["dep:strum", "dep:strum_macros"]

--- a/core/benches/benchmark_lexer.rs
+++ b/core/benches/benchmark_lexer.rs
@@ -1,8 +1,8 @@
 use std::{ops::Range, time::Duration};
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use pasfmt_core::prelude::*;
-use rand::{seq::SliceRandom, Rng};
+use rand::{Rng, seq::SliceRandom};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("lexer");

--- a/core/datatests/Cargo.toml
+++ b/core/datatests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "datatests"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 
 [dev-dependencies]
 datatest-stable = { workspace = true }

--- a/core/datatests/tests/suites/logical_line_parser.rs
+++ b/core/datatests/tests/suites/logical_line_parser.rs
@@ -469,7 +469,10 @@ impl Display for TestParsingError {
                 write!(f, "{PREFIX}marker must succeed another token '{input}'")
             }
             TestParsingError::NoLineTypeDelimiter(input) => {
-                write!(f, "{PREFIX}no logical line type declaration delimiter '{input}' (expected `number:LogicalLineType`)")
+                write!(
+                    f,
+                    "{PREFIX}no logical line type declaration delimiter '{input}' (expected `number:LogicalLineType`)"
+                )
             }
             TestParsingError::InvalidLogicalLineType(input) => {
                 write!(f, "{PREFIX}invalid logical line type '{input}'")

--- a/core/src/defaults/lexer.rs
+++ b/core/src/defaults/lexer.rs
@@ -534,10 +534,10 @@ fn get_word_token_type(input: &str) -> RawTokenType {
 
     if input.len() <= MAX_WORD_LENGTH {
         let key = hash_keyword(input) as usize;
-        if let Some(Some((candidate, keyword))) = KEYWORD_LOOKUP_TABLE.get(key) {
-            if input.eq_ignore_ascii_case(candidate) {
-                return *keyword;
-            }
+        if let Some(Some((candidate, keyword))) = KEYWORD_LOOKUP_TABLE.get(key)
+            && input.eq_ignore_ascii_case(candidate)
+        {
+            return *keyword;
         }
     }
 

--- a/core/src/defaults/lexer.rs
+++ b/core/src/defaults/lexer.rs
@@ -2673,7 +2673,7 @@ mod tests {
                 ("THIN_SPACE\u{2009}", TT::Identifier),
                 ("ZERO_WIDTH_NBSP\u{FEFF}", TT::Identifier),
                 // note, does not contain the U+3000 character
-                ( "IDEOGRAPHIC_SPACE", TT::Identifier),
+                ("IDEOGRAPHIC_SPACE", TT::Identifier),
             ],
         )
     }

--- a/core/src/defaults/lexer.rs
+++ b/core/src/defaults/lexer.rs
@@ -1263,7 +1263,7 @@ fn ampersand(mut args: LexArgs) -> OffsetAndTokenType {
 // region: operators
 
 macro_rules! basic_op {
-    ($name: ident, $typ: expr_2021) => {
+    ($name: ident, $typ: expr) => {
         fn $name(args: LexArgs) -> OffsetAndTokenType {
             (args.offset, RawTokenType::Op($typ))
         }

--- a/core/src/defaults/lexer.rs
+++ b/core/src/defaults/lexer.rs
@@ -1263,7 +1263,7 @@ fn ampersand(mut args: LexArgs) -> OffsetAndTokenType {
 // region: operators
 
 macro_rules! basic_op {
-    ($name: ident, $typ: expr) => {
+    ($name: ident, $typ: expr_2021) => {
         fn $name(args: LexArgs) -> OffsetAndTokenType {
             (args.offset, RawTokenType::Op($typ))
         }

--- a/core/src/defaults/parser.rs
+++ b/core/src/defaults/parser.rs
@@ -610,19 +610,19 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
             level,
         });
 
-        if self.context.is_ended.last() == Some(&false) {
-            if let Some(KK::Else) = self.get_current_keyword_kind() {
-                let parent = self.get_line_parent_of_current_token();
-                self.next_token(); // else
+        if self.context.is_ended.last() == Some(&false)
+            && let Some(KK::Else) = self.get_current_keyword_kind()
+        {
+            let parent = self.get_line_parent_of_current_token();
+            self.next_token(); // else
 
-                trace!("Parse `else` statement");
-                level = ParserContextLevel::Parent(parent, 1);
-                self.parse_block(ParserContext {
-                    context_type: ContextType::Statement(StatementKind::Normal),
-                    context_ending_predicate: CEP::Transparent(never_ending),
-                    level,
-                });
-            }
+            trace!("Parse `else` statement");
+            level = ParserContextLevel::Parent(parent, 1);
+            self.parse_block(ParserContext {
+                context_type: ContextType::Statement(StatementKind::Normal),
+                context_ending_predicate: CEP::Transparent(never_ending),
+                level,
+            });
         }
 
         trace!("Finished parsing `if` statement");
@@ -861,8 +861,8 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
                     self.context.update_statuses(ending_context);
                     return;
                 }
-                if self.is_at_start_of_line() {
-                    if let Some(line_type) = match context.context_type {
+                if self.is_at_start_of_line()
+                    && let Some(line_type) = match context.context_type {
                         ContextType::Statement(StatementKind::Case) => Some(LLT::CaseArm),
                         ContextType::LabelBlock
                         | ContextType::TypeBlock
@@ -872,9 +872,9 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
                             Some(LLT::VariantRecordCaseArm)
                         }
                         _ => None,
-                    } {
-                        self.set_logical_line_type(line_type);
                     }
+                {
+                    self.set_logical_line_type(line_type);
                 }
             }
             trace!("parse_statement with {:?}", token_type);
@@ -1749,10 +1749,9 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
             if let Some(TT::IdentifierOrKeyword(
                 directive @ (KK::Deprecated | KK::Experimental | KK::Platform | KK::Library),
             )) = self.tokens.get(token_index).map(RawToken::get_token_type)
+                && let Some(token) = self.tokens.get_mut(token_index)
             {
-                if let Some(token) = self.tokens.get_mut(token_index) {
-                    token.set_token_type(TT::Keyword(directive))
-                }
+                token.set_token_type(TT::Keyword(directive))
             }
 
             line_index -= 1;
@@ -1928,10 +1927,9 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
             .checked_sub(1)
             .and_then(|prev_pass_index| self.pass_indices.get(prev_pass_index))
             .and_then(|&token_index| self.tokens.get_mut(token_index))
+            && let TT::IdentifierOrKeyword(keyword_kind) = token.get_token_type()
         {
-            if let TT::IdentifierOrKeyword(keyword_kind) = token.get_token_type() {
-                token.set_token_type(TT::Keyword(keyword_kind));
-            }
+            token.set_token_type(TT::Keyword(keyword_kind));
         }
     }
     fn get_token_type_for_index(&self, index: usize) -> Option<RawTokenType> {
@@ -2019,17 +2017,17 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
             .and_then(Self::get_keyword_kind)
     }
     fn consolidate_current_ident(&mut self) {
-        if let Some(token) = self.get_token_mut::<0>() {
-            if let TT::IdentifierOrKeyword(_) = token.get_token_type() {
-                token.set_token_type(TT::Identifier);
-            }
+        if let Some(token) = self.get_token_mut::<0>()
+            && let TT::IdentifierOrKeyword(_) = token.get_token_type()
+        {
+            token.set_token_type(TT::Identifier);
         }
     }
     fn consolidate_current_keyword(&mut self) {
-        if let Some(token) = self.get_token_mut::<0>() {
-            if let TT::IdentifierOrKeyword(keyword_kind) = token.get_token_type() {
-                token.set_token_type(TT::Keyword(keyword_kind));
-            }
+        if let Some(token) = self.get_token_mut::<0>()
+            && let TT::IdentifierOrKeyword(keyword_kind) = token.get_token_type()
+        {
+            token.set_token_type(TT::Keyword(keyword_kind));
         }
     }
     fn set_current_token_type(&mut self, token_type: RawTokenType) {
@@ -2306,10 +2304,10 @@ const PORTABILITY_DIRECTIVES: [KeywordKind; 4] =
     [KK::Deprecated, KK::Experimental, KK::Platform, KK::Library];
 fn keyword_consolidator(keyword_predicate: impl Fn(KeywordKind) -> bool) -> impl Fn(&mut LLP) {
     move |parser| {
-        if let Some(TT::IdentifierOrKeyword(keyword_kind)) = parser.get_current_token_type() {
-            if keyword_predicate(keyword_kind) {
-                parser.consolidate_current_keyword()
-            }
+        if let Some(TT::IdentifierOrKeyword(keyword_kind)) = parser.get_current_token_type()
+            && keyword_predicate(keyword_kind)
+        {
+            parser.consolidate_current_keyword()
         }
         parser.next_token();
     }

--- a/core/src/defaults/parser.rs
+++ b/core/src/defaults/parser.rs
@@ -1847,7 +1847,7 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
     }
     fn get_current_logical_line_token_types(
         &self,
-    ) -> impl DoubleEndedIterator<Item = RawTokenType> + '_ + use<'_> {
+    ) -> impl DoubleEndedIterator<Item = RawTokenType> + use<'_> {
         self.get_current_logical_line()
             .tokens
             .iter()

--- a/core/src/defaults/parser.rs
+++ b/core/src/defaults/parser.rs
@@ -1847,7 +1847,7 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
     }
     fn get_current_logical_line_token_types(
         &self,
-    ) -> impl DoubleEndedIterator<Item = RawTokenType> + '_ {
+    ) -> impl DoubleEndedIterator<Item = RawTokenType> + '_ + use<'_> {
         self.get_current_logical_line()
             .tokens
             .iter()

--- a/core/src/defaults/parser/token_consolidation_tests.rs
+++ b/core/src/defaults/parser/token_consolidation_tests.rs
@@ -67,7 +67,7 @@ fn run_casing_token_consolidation_test(input: &str) {
 }
 
 macro_rules! casing_token_consolidation_test {
-    ($suite_name:ident, $($case_name: ident = { $input: expr_2021 $(,)? }),* $(,)?) => {
+    ($suite_name:ident, $($case_name: ident = { $input: expr $(,)? }),* $(,)?) => {
         #[yare::parameterized(
             $($case_name = { $input }),*
         )]
@@ -258,7 +258,7 @@ casing_token_consolidation_test!(
 );
 
 macro_rules! casing_property_declaration_consolidation_test(
-    ($($case_name: ident = { $input: expr_2021 $(,)? }),* $(,)?) => {
+    ($($case_name: ident = { $input: expr $(,)? }),* $(,)?) => {
         #[yare::parameterized(
             $($case_name = { &format!("type foo = class {} end", $input) }),*
         )]
@@ -312,12 +312,12 @@ casing_property_declaration_consolidation_test!(
 macro_rules! portability_directive_consolidation_test_end_semicolon {
     (
         $suite_name: ident,
-        $directive: expr_2021,
+        $directive: expr,
         :end_semicolon:
-            $($case_name: ident = { $input: expr_2021 $(,)? }),*
+            $($case_name: ident = { $input: expr $(,)? }),*
         $(,)?
         :manual_semicolon:
-            $($no_sc_case_name: ident = { $no_sc_input: expr_2021 $(,)? }),*
+            $($no_sc_case_name: ident = { $no_sc_input: expr $(,)? }),*
         $(,)?
     ) => {
         paste::paste! {
@@ -432,7 +432,7 @@ casing_token_consolidation_test!(
 );
 
 macro_rules! property_expression_parsing_consolidation_test(
-    ($($case_name: ident = { $input: expr_2021 $(,)? }),* $(,)?) => {
+    ($($case_name: ident = { $input: expr $(,)? }),* $(,)?) => {
         #[yare::parameterized(
             $($case_name = { &format!("type TFoo = class property foo: foo index {} nodefault end", $input) }),*
         )]

--- a/core/src/defaults/parser/token_consolidation_tests.rs
+++ b/core/src/defaults/parser/token_consolidation_tests.rs
@@ -67,7 +67,7 @@ fn run_casing_token_consolidation_test(input: &str) {
 }
 
 macro_rules! casing_token_consolidation_test {
-    ($suite_name:ident, $($case_name: ident = { $input: expr $(,)? }),* $(,)?) => {
+    ($suite_name:ident, $($case_name: ident = { $input: expr_2021 $(,)? }),* $(,)?) => {
         #[yare::parameterized(
             $($case_name = { $input }),*
         )]
@@ -258,7 +258,7 @@ casing_token_consolidation_test!(
 );
 
 macro_rules! casing_property_declaration_consolidation_test(
-    ($($case_name: ident = { $input: expr $(,)? }),* $(,)?) => {
+    ($($case_name: ident = { $input: expr_2021 $(,)? }),* $(,)?) => {
         #[yare::parameterized(
             $($case_name = { &format!("type foo = class {} end", $input) }),*
         )]
@@ -312,12 +312,12 @@ casing_property_declaration_consolidation_test!(
 macro_rules! portability_directive_consolidation_test_end_semicolon {
     (
         $suite_name: ident,
-        $directive: expr,
+        $directive: expr_2021,
         :end_semicolon:
-            $($case_name: ident = { $input: expr $(,)? }),*
+            $($case_name: ident = { $input: expr_2021 $(,)? }),*
         $(,)?
         :manual_semicolon:
-            $($no_sc_case_name: ident = { $no_sc_input: expr $(,)? }),*
+            $($no_sc_case_name: ident = { $no_sc_input: expr_2021 $(,)? }),*
         $(,)?
     ) => {
         paste::paste! {
@@ -432,7 +432,7 @@ casing_token_consolidation_test!(
 );
 
 macro_rules! property_expression_parsing_consolidation_test(
-    ($($case_name: ident = { $input: expr $(,)? }),* $(,)?) => {
+    ($($case_name: ident = { $input: expr_2021 $(,)? }),* $(,)?) => {
         #[yare::parameterized(
             $($case_name = { &format!("type TFoo = class property foo: foo index {} nodefault end", $input) }),*
         )]

--- a/core/src/formatter.rs
+++ b/core/src/formatter.rs
@@ -842,10 +842,10 @@ else
     impl LogicalLineFormatter for AddSpaceBeforeIdentifier {
         fn format(&self, formatted_tokens: &mut FormattedTokens<'_>, input: &LogicalLine) {
             for &token in input.get_tokens() {
-                if formatted_tokens.get_token_type_for_index(token) == Some(TokenType::Identifier) {
-                    if let Some(formatting_data) = formatted_tokens.get_formatting_data_mut(token) {
-                        formatting_data.spaces_before = 1;
-                    }
+                if formatted_tokens.get_token_type_for_index(token) == Some(TokenType::Identifier)
+                    && let Some(formatting_data) = formatted_tokens.get_formatting_data_mut(token)
+                {
+                    formatting_data.spaces_before = 1;
                 }
             }
         }
@@ -965,15 +965,13 @@ else
     struct LogicalLinesOnNewLines;
     impl LogicalLineFormatter for LogicalLinesOnNewLines {
         fn format(&self, formatted_tokens: &mut FormattedTokens<'_>, input: &LogicalLine) {
-            if let Some(&first_token) = input.get_tokens().first() {
-                if first_token != 0 && first_token != formatted_tokens.len() - 1 {
-                    if let Some(formatting_data) =
-                        formatted_tokens.get_formatting_data_mut(first_token)
-                    {
-                        formatting_data.spaces_before = 0;
-                        formatting_data.newlines_before = 1;
-                    }
-                }
+            if let Some(&first_token) = input.get_tokens().first()
+                && first_token != 0
+                && first_token != formatted_tokens.len() - 1
+                && let Some(formatting_data) = formatted_tokens.get_formatting_data_mut(first_token)
+            {
+                formatting_data.spaces_before = 0;
+                formatting_data.newlines_before = 1;
             }
         }
     }
@@ -1158,11 +1156,11 @@ else
     impl LogicalLineFormatter for RetainSpacesLogcialLinesOnNewLines {
         fn format(&self, formatted_tokens: &mut FormattedTokens<'_>, input: &LogicalLine) {
             let first_token = *input.get_tokens().first().unwrap();
-            if first_token != 0 && first_token != formatted_tokens.len() - 1 {
-                if let Some(formatting_data) = formatted_tokens.get_formatting_data_mut(first_token)
-                {
-                    formatting_data.newlines_before = 1;
-                }
+            if first_token != 0
+                && first_token != formatted_tokens.len() - 1
+                && let Some(formatting_data) = formatted_tokens.get_formatting_data_mut(first_token)
+            {
+                formatting_data.newlines_before = 1;
             }
         }
     }

--- a/core/src/lang.rs
+++ b/core/src/lang.rs
@@ -613,7 +613,7 @@ impl<'a> FormattedTokens<'a> {
     pub fn tokens_mut(
         &mut self,
     ) -> impl DoubleEndedIterator<Item = (Result<&mut Token<'a>, MutTokenErr>, &mut FormattingData)>
-           + ExactSizeIterator {
+    + ExactSizeIterator {
         self.tokens
             .iter_mut()
             .zip(&mut self.fmt)

--- a/core/src/rules/generics_consolidator.rs
+++ b/core/src/rules/generics_consolidator.rs
@@ -64,28 +64,27 @@ impl TokenConsolidator for DistinguishGenericTypeParamsConsolidator {
                         ),
                     ) => {}
                     Some(TokenType::Op(OperatorKind::GreaterThan(_))) => {
-                        if comma_found {
-                            if let Some(
+                        if comma_found
+                            && let Some(
                                 TokenType::Identifier
                                 | TokenType::Op(OperatorKind::AddressOf)
                                 | TokenType::Keyword(KeywordKind::Not),
                             ) = tokens.get(next_idx + 1).map(TokenData::get_token_type)
-                            {
-                                // cases where it cannot be generics
-                                //   Foo(X < Y, U > V)
-                                //   Foo(X < Y, U > @V)
-                                //   Foo(X < Y, U > not V)
+                        {
+                            // cases where it cannot be generics
+                            //   Foo(X < Y, U > V)
+                            //   Foo(X < Y, U > @V)
+                            //   Foo(X < Y, U > not V)
 
-                                // cases where it is ambiguous but we prefer to treat it as generics
-                                //   Foo(X < Y, U > +V)
-                                //   Foo(X < Y, U > -V)
-                                //   Foo(X < Y, U > (V))
-                                //   Foo(X < Y, U > [V])
+                            // cases where it is ambiguous but we prefer to treat it as generics
+                            //   Foo(X < Y, U > +V)
+                            //   Foo(X < Y, U > -V)
+                            //   Foo(X < Y, U > (V))
+                            //   Foo(X < Y, U > [V])
 
-                                // cases where it must be generics
-                                //   Foo(X < Y, U > /V)   (or any other binary operator)
-                                break;
-                            }
+                            // cases where it must be generics
+                            //   Foo(X < Y, U > /V)   (or any other binary operator)
+                            break;
                         }
 
                         let closed_state = state.pop().unwrap();

--- a/core/src/rules/ignore_asm_instructions.rs
+++ b/core/src/rules/ignore_asm_instructions.rs
@@ -28,10 +28,9 @@ mod tests {
         fn format(&self, formatted_tokens: &mut FormattedTokens<'_>, _input: &[LogicalLine]) {
             for token_index in 1..formatted_tokens.len() {
                 if let Some(formatting_data) = formatted_tokens.get_formatting_data_mut(token_index)
+                    && formatting_data.newlines_before == 0
                 {
-                    if formatting_data.newlines_before == 0 {
-                        formatting_data.spaces_before = 1;
-                    }
+                    formatting_data.spaces_before = 1;
                 }
             }
         }

--- a/core/src/rules/optimising_line_formatter/contexts.rs
+++ b/core/src/rules/optimising_line_formatter/contexts.rs
@@ -1283,7 +1283,7 @@ impl<'builder> LineFormattingContextsBuilder<'builder> {
             member_access_contexts: NodeRefSet::new(),
         }
     }
-    fn type_stack(&self) -> impl Iterator<Item = ContextType> + 'builder + use<'builder> {
+    fn type_stack(&self) -> impl Iterator<Item = ContextType> + use<'builder> {
         self.current_context
             .walk_parents_data()
             .map(|index| index.context_type)

--- a/core/src/rules/optimising_line_formatter/contexts.rs
+++ b/core/src/rules/optimising_line_formatter/contexts.rs
@@ -374,12 +374,13 @@ impl<'a> SpecificContextStack<'a> {
         filter: impl ContextFilter,
         operation: impl Fn(Ref<'_, FormattingContext>, &mut FormattingContextState),
     ) -> bool {
-        match self.get_last_matching_context_mut(node, filter) { Some((context, data)) => {
-            operation(context, data);
-            true
-        } _ => {
-            false
-        }}
+        match self.get_last_matching_context_mut(node, filter) {
+            Some((context, data)) => {
+                operation(context, data);
+                true
+            }
+            _ => false,
+        }
     }
     fn update_operator_precedences(&self, node: &mut FormattingNode, is_break: bool) {
         self.update_last_matching_context(

--- a/core/src/rules/optimising_line_formatter/contexts.rs
+++ b/core/src/rules/optimising_line_formatter/contexts.rs
@@ -733,12 +733,11 @@ impl<'a> SpecificContextStack<'a> {
                 data.is_child_broken = true;
                 data.break_anonymous_routine = Some(true);
             });
-        } else if !child_solutions.is_empty() {
-            if let Some((_, context)) =
+        } else if !child_solutions.is_empty()
+            && let Some((_, context)) =
                 self.get_last_matching_context_mut(node, CT::ControlFlowBegin)
-            {
-                context.can_break = false;
-            }
+        {
+            context.can_break = false;
         }
     }
 }

--- a/core/src/rules/optimising_line_formatter/contexts.rs
+++ b/core/src/rules/optimising_line_formatter/contexts.rs
@@ -337,7 +337,7 @@ impl<'a> SpecificContextStack<'a> {
     /// indices. Typically for modification.
     pub(super) fn ctx_iter_indices(
         &self,
-    ) -> impl Iterator<Item = (usize, Ref<'a, FormattingContext>)> {
+    ) -> impl Iterator<Item = (usize, Ref<'a, FormattingContext>)> + use<'a> {
         self.stack
             .into_iter()
             .flat_map(|stack| stack.walk_parents())
@@ -374,12 +374,12 @@ impl<'a> SpecificContextStack<'a> {
         filter: impl ContextFilter,
         operation: impl Fn(Ref<'_, FormattingContext>, &mut FormattingContextState),
     ) -> bool {
-        if let Some((context, data)) = self.get_last_matching_context_mut(node, filter) {
+        match self.get_last_matching_context_mut(node, filter) { Some((context, data)) => {
             operation(context, data);
             true
-        } else {
+        } _ => {
             false
-        }
+        }}
     }
     fn update_operator_precedences(&self, node: &mut FormattingNode, is_break: bool) {
         self.update_last_matching_context(
@@ -1282,7 +1282,7 @@ impl<'builder> LineFormattingContextsBuilder<'builder> {
             member_access_contexts: NodeRefSet::new(),
         }
     }
-    fn type_stack(&self) -> impl Iterator<Item = ContextType> + 'builder {
+    fn type_stack(&self) -> impl Iterator<Item = ContextType> + 'builder + use<'builder> {
         self.current_context
             .walk_parents_data()
             .map(|index| index.context_type)

--- a/core/src/rules/optimising_line_formatter/mod.rs
+++ b/core/src/rules/optimising_line_formatter/mod.rs
@@ -85,10 +85,10 @@ impl LogicalLineFileFormatter for OptimisingLineFormatter {
             provided by `TokenSpacing` can be removed at the starts of lines.
         */
         for token_index in 0..olf.formatted_tokens.len() {
-            if let Some(data) = olf.formatted_tokens.get_formatting_data_mut(token_index) {
-                if data.newlines_before > 0 {
-                    data.spaces_before = 0;
-                }
+            if let Some(data) = olf.formatted_tokens.get_formatting_data_mut(token_index)
+                && data.newlines_before > 0
+            {
+                data.spaces_before = 0;
             }
         }
 

--- a/core/src/rules/optimising_line_formatter/mod.rs
+++ b/core/src/rules/optimising_line_formatter/mod.rs
@@ -3,8 +3,8 @@
 //!
 
 use std::cell::RefCell;
-use std::collections::hash_map::Entry;
 use std::collections::BinaryHeap;
+use std::collections::hash_map::Entry;
 use std::rc::Rc;
 
 use debug::DebugFormattingNode;
@@ -591,8 +591,7 @@ impl<'this> InternalOptimisingLineFormatter<'this, '_> {
                     if last_line_length > self.settings.max_line_length {
                         trace!(
                             "Last line length {} > max line length {}, line is too long",
-                            last_line_length,
-                            self.settings.max_line_length
+                            last_line_length, self.settings.max_line_length
                         );
                         if let Some((indiff, _stack)) = indifference_line {
                             trace!(
@@ -649,7 +648,9 @@ impl<'this> InternalOptimisingLineFormatter<'this, '_> {
                             // indifferent and add its possibilities.
 
                             if let Some((indiff, stack)) = indifference_line {
-                                trace!("Returning to first `Indifferent` decision to push all successors");
+                                trace!(
+                                    "Returning to first `Indifferent` decision to push all successors"
+                                );
                                 node_successors.extend(get_solutions(
                                     NL::Break,
                                     indiff.clone(),
@@ -714,7 +715,9 @@ impl<'this> InternalOptimisingLineFormatter<'this, '_> {
                         trace!("Continuing to explore single successor branch");
                     } else {
                         if let Some((indiff, stack)) = indifference_line {
-                            trace!("Multiple successors found, returning to first `Indifferent` decision to push all successors");
+                            trace!(
+                                "Multiple successors found, returning to first `Indifferent` decision to push all successors"
+                            );
                             node_successors.extend(get_solutions(
                                 NL::Break,
                                 indiff.clone(),

--- a/core/src/rules/optimising_line_formatter/multiline_strings.rs
+++ b/core/src/rules/optimising_line_formatter/multiline_strings.rs
@@ -43,7 +43,9 @@ impl StringFormatter<'_> {
             let base_indentation = &last_line[0..count_leading_whitespace(last_line)];
 
             if base_indentation.len() != last_line.trim_end_matches('\'').len() {
-                log::warn!("Last line of multiline string contains non-whitespace before trailing quote: {last_line:?}");
+                log::warn!(
+                    "Last line of multiline string contains non-whitespace before trailing quote: {last_line:?}"
+                );
                 continue;
             };
 
@@ -83,7 +85,9 @@ impl StringFormatter<'_> {
                     continue;
                 }
 
-                log::warn!("Whitespace inside line of multiline string does not match whitespace before trailing quote: {line:?}");
+                log::warn!(
+                    "Whitespace inside line of multiline string does not match whitespace before trailing quote: {line:?}"
+                );
                 return None;
             };
 

--- a/core/src/rules/optimising_line_formatter/multiline_strings.rs
+++ b/core/src/rules/optimising_line_formatter/multiline_strings.rs
@@ -51,11 +51,10 @@ impl StringFormatter<'_> {
 
             if let Some(new_string_contents) =
                 self.try_rewrite_string(tok.get_content(), fmt, base_indentation)
+                && new_string_contents != tok.get_content()
             {
-                if new_string_contents != tok.get_content() {
-                    tok.set_content(new_string_contents);
-                    changed = true
-                }
+                tok.set_content(new_string_contents);
+                changed = true
             }
         }
         changed

--- a/core/src/rules/optimising_line_formatter/parent_pointer_tree.rs
+++ b/core/src/rules/optimising_line_formatter/parent_pointer_tree.rs
@@ -178,12 +178,12 @@ impl<'list, T> NodeRef<'list, T> {
 
     /// Iterates from a node through its parents while providing direct access
     /// to their data
-    pub fn walk_parents_data(&self) -> impl Iterator<Item = Ref<'list, T>> {
+    pub fn walk_parents_data(&self) -> impl Iterator<Item = Ref<'list, T>> + use<'list, T> {
         self.walk_parents().map(|node| node.get())
     }
 
     /// Iterate from a node through its parent nodes
-    pub fn walk_parents(&self) -> impl Iterator<Item = NodeRef<'list, T>> {
+    pub fn walk_parents(&self) -> impl Iterator<Item = NodeRef<'list, T>> + use<'list, T> {
         NodeRefIter {
             next_node: Some(self.index),
             tree: self.list,

--- a/core/src/rules/optimising_line_formatter/requirements.rs
+++ b/core/src/rules/optimising_line_formatter/requirements.rs
@@ -1,9 +1,9 @@
+use super::InternalOptimisingLineFormatter;
+use super::SpecificContextDataStack;
 use super::contexts::*;
 use super::get_operator_precedence;
 use super::is_binary;
 use super::types::DecisionRequirement;
-use super::InternalOptimisingLineFormatter;
-use super::SpecificContextDataStack;
 use crate::lang::*;
 
 use super::contexts::ContextType as CT;

--- a/core/src/rules/token_spacing.rs
+++ b/core/src/rules/token_spacing.rs
@@ -315,7 +315,7 @@ mod tests {
     );
 
     macro_rules! binary_op_cases {
-        ($(($name: ident, $symbol: expr_2021)),* $(,)?)=> {
+        ($(($name: ident, $symbol: expr)),* $(,)?)=> {
             formatter_test_group!(
                 binary_operators,
                 $($name = {concat!("A  ", $symbol, "  B"), concat!("A ", $symbol, " B")}),*

--- a/core/src/rules/token_spacing.rs
+++ b/core/src/rules/token_spacing.rs
@@ -315,7 +315,7 @@ mod tests {
     );
 
     macro_rules! binary_op_cases {
-        ($(($name: ident, $symbol: expr)),* $(,)?)=> {
+        ($(($name: ident, $symbol: expr_2021)),* $(,)?)=> {
             formatter_test_group!(
                 binary_operators,
                 $($name = {concat!("A  ", $symbol, "  B"), concat!("A ", $symbol, " B")}),*

--- a/core/src/rules/token_spacing.rs
+++ b/core/src/rules/token_spacing.rs
@@ -28,20 +28,19 @@ impl LogicalLineFileFormatter for TokenSpacing {
                 _ => max_one_either_side(token_index, formatted_tokens),
             };
 
-            if let Some(spaces_before) = spaces_before {
-                if let Some(formatting_data) = formatted_tokens.get_formatting_data_mut(token_index)
-                {
-                    formatting_data.spaces_before = spaces_before;
-                }
+            if let Some(spaces_before) = spaces_before
+                && let Some(formatting_data) = formatted_tokens.get_formatting_data_mut(token_index)
+            {
+                formatting_data.spaces_before = spaces_before;
             }
 
             if let Some(spaces_after) = spaces_after {
                 let next_idx = token_index + 1;
                 let next_token_type = formatted_tokens.get_token_type_for_index(next_idx);
-                if let Some(formatting_data) = formatted_tokens.get_formatting_data_mut(next_idx) {
-                    if next_token_type != Some(TT::Eof) {
-                        formatting_data.spaces_before = spaces_after;
-                    }
+                if let Some(formatting_data) = formatted_tokens.get_formatting_data_mut(next_idx)
+                    && next_token_type != Some(TT::Eof)
+                {
+                    formatting_data.spaces_before = spaces_after;
                 }
             }
         }

--- a/core/src/test_utils.rs
+++ b/core/src/test_utils.rs
@@ -3,7 +3,7 @@
 use crate::prelude::*;
 
 macro_rules! formatter_test_group {
-    ($i:ident, $($case_name: ident = {$($e: expr),* $(,)?}),* $(,)?) => {
+    ($i:ident, $($case_name: ident = {$($e: expr_2021),* $(,)?}),* $(,)?) => {
         #[yare::parameterized(
           $($case_name = { $($e),* }),*
         )]

--- a/core/src/test_utils.rs
+++ b/core/src/test_utils.rs
@@ -3,7 +3,7 @@
 use crate::prelude::*;
 
 macro_rules! formatter_test_group {
-    ($i:ident, $($case_name: ident = {$($e: expr_2021),* $(,)?}),* $(,)?) => {
+    ($i:ident, $($case_name: ident = {$($e: expr),* $(,)?}),* $(,)?) => {
         #[yare::parameterized(
           $($case_name = { $($e),* }),*
         )]

--- a/front-end/Cargo.toml
+++ b/front-end/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pasfmt"
 version = "0.7.0+dev"
-edition = "2021"
+edition = "2024"
 
 # To allow splitting integration tests into separate files without creating multiple test binaries
 autotests = false

--- a/front-end/benches/benchmark_submodules.rs
+++ b/front-end/benches/benchmark_submodules.rs
@@ -5,14 +5,14 @@ use std::{
     fs::OpenOptions,
     io::Read,
     path::{Path, PathBuf},
-    process::{exit, Command},
+    process::{Command, exit},
     time::Duration,
 };
 use walkdir::WalkDir;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
-use pasfmt::{format, FormattingConfig};
+use pasfmt::{FormattingConfig, format};
 use pasfmt_orchestrator::predule::*;
 
 pasfmt_config!(Config<FormattingConfig>);

--- a/front-end/src/main.rs
+++ b/front-end/src/main.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 
 use log::error;
-use pasfmt::{format, FormattingConfig};
+use pasfmt::{FormattingConfig, format};
 use pasfmt_orchestrator::predule::*;
 
 pasfmt_config!(

--- a/front-end/tests/file_discovery.rs
+++ b/front-end/tests/file_discovery.rs
@@ -1,4 +1,4 @@
-use assert_fs::{prelude::*, TempDir};
+use assert_fs::{TempDir, prelude::*};
 use predicates::prelude::*;
 use std::path::Path;
 use std::path::PathBuf;

--- a/front-end/tests/idempotence.rs
+++ b/front-end/tests/idempotence.rs
@@ -1,4 +1,4 @@
-use assert_fs::{prelude::*, TempDir};
+use assert_fs::{TempDir, prelude::*};
 use predicates::prelude::*;
 
 use crate::utils::windows::fmt_with_lock;

--- a/front-end/tests/logging.rs
+++ b/front-end/tests/logging.rs
@@ -1,4 +1,4 @@
-use assert_fs::{prelude::*, TempDir};
+use assert_fs::{TempDir, prelude::*};
 use predicates::prelude::*;
 
 use crate::utils::*;

--- a/front-end/tests/modes.rs
+++ b/front-end/tests/modes.rs
@@ -1,4 +1,4 @@
-use assert_fs::{prelude::*, TempDir};
+use assert_fs::{TempDir, prelude::*};
 use predicates::prelude::*;
 use std::fs::read_to_string;
 use std::path::Path;

--- a/front-end/tests/utils.rs
+++ b/front-end/tests/utils.rs
@@ -23,7 +23,7 @@ pub mod windows {
     use std::os::windows::io::AsRawHandle;
     use std::path::Path;
     use windows_sys::Win32::{
-        Storage::FileSystem::{LockFileEx, LOCK_FILE_FLAGS},
+        Storage::FileSystem::{LOCK_FILE_FLAGS, LockFileEx},
         System::IO::OVERLAPPED,
     };
 

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pasfmt-orchestrator"
 version = "0.4.0+dev"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 clap = { workspace = true, features = ["derive", "wrap_help"] }

--- a/orchestrator/src/command_line.rs
+++ b/orchestrator/src/command_line.rs
@@ -9,14 +9,14 @@ use std::{
 
 use anstyle::AnsiColor;
 use anyhow::Context;
-pub use clap::{self, error::ErrorKind, CommandFactory, Parser};
+pub use clap::{self, CommandFactory, Parser, error::ErrorKind};
 use clap::{
-    builder::{PossibleValuesParser, StyledStr, Styles, TypedValueParser},
     Args, ValueEnum,
+    builder::{PossibleValuesParser, StyledStr, Styles, TypedValueParser},
 };
 
 use config::{Config, File, FileFormat};
-use log::{debug, LevelFilter};
+use log::{LevelFilter, debug};
 
 use crate::formatting_orchestrator::FormatterConfiguration;
 
@@ -389,7 +389,7 @@ impl<C: Configuration> FormatterConfiguration for PasFmtConfiguration<C> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use assert_fs::{prelude::*, TempDir};
+    use assert_fs::{TempDir, prelude::*};
     use serde::Deserialize;
     use spectral::prelude::*;
 

--- a/orchestrator/src/file_formatter.rs
+++ b/orchestrator/src/file_formatter.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use encoding_rs::Encoding;
 use log::*;
 use std::{

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "web"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1,4 +1,4 @@
-use pasfmt::{make_formatter, FormattingConfig};
+use pasfmt::{FormattingConfig, make_formatter};
 use pasfmt_core::prelude::FileOptions;
 use wasm_bindgen::prelude::*;
 


### PR DESCRIPTION
- **Migrate to Rust 2024 edition**
- **Format with rustfmt 2024 edition**
- **Convert `expr_2021` macro fragment to `expr`**
- **Simplify new `use<..>` bounds**
- **Auto apply clippy lint for if-let chains**
