### PR TITLE
Fixed parsing of logical lines with sequential `<` and `>` comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed parsing of logical lines with sequential `<` and `>` comparisons.
+
 ### Added
 
 - Added support for Delphi 13 `noreturn` directive.

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed parsing of logical lines with sequential `<` and `>` comparisons.
+
 ### Added
 
 - Added support for Delphi 13 `noreturn` directive.

--- a/core/datatests/generators/logical_line_parser.rs
+++ b/core/datatests/generators/logical_line_parser.rs
@@ -3447,7 +3447,12 @@ mod regression {
                 _|  Protected = 0;
                 _|  Public = 0;
                 _|  Published = 0;
-            "
+            ",
+            non_generic_statements = "
+                _|A := B < C;
+                _|raise D(E > F);
+                _|X := Y;
+            ",
         );
     }
 }

--- a/core/src/defaults/parser.rs
+++ b/core/src/defaults/parser.rs
@@ -1795,6 +1795,10 @@ impl<'a, 'b> InternalDelphiLogicalLineParser<'a, 'b> {
     }
 
     fn finish_logical_line(&mut self) {
+        self.generic_level = 0;
+        self.brack_level = 0;
+        self.paren_level = 0;
+
         if self.is_at_start_of_line() {
             self.get_current_logical_line_mut().line_type = LLT::Unknown;
             return;


### PR DESCRIPTION
This change resets the `generic_level` when a new line is created. This
ensures that between lines, there are no interactions between `<` and
`>` operations.

This change fixes #298.