### PR TITLE
Fix new clippy lints in Rust v1.97

### DIFF
--- a/core/datatests/build.rs
+++ b/core/datatests/build.rs
@@ -22,7 +22,7 @@ fn main() {
         std::fs::create_dir(&test_root_dir).unwrap_or_else(|e| {
             panic!(
                 "failed to create directory '{}', {e}",
-                &test_root_dir.display()
+                test_root_dir.display()
             )
         })
     }
@@ -39,8 +39,8 @@ fn main() {
         std::fs::rename(&staging_test_root_dir, &test_root_dir).unwrap_or_else(|e| {
             panic!(
                 "unable to rename '{}' to '{}', {e}",
-                &staging_test_root_dir.display(),
-                &test_root_dir.display()
+                staging_test_root_dir.display(),
+                test_root_dir.display()
             )
         });
     } else {
@@ -52,7 +52,7 @@ fn remove_dir_if_present(path: &PathBuf) {
     match std::fs::remove_dir_all(path) {
         Ok(()) => {}
         Err(e) if matches!(e.kind(), ErrorKind::NotFound) => {}
-        Err(e) => panic!("unable to remove {}, {}", &path.display(), e),
+        Err(e) => panic!("unable to remove {}, {}", path.display(), e),
     };
 }
 
@@ -79,8 +79,8 @@ fn get_dir_entries(root: &PathBuf) -> Vec<DirEntry> {
 fn read_file_bytes(file: &DirEntry) -> Vec<u8> {
     let mut contents = vec![];
     File::open(file.clone().into_path())
-        .unwrap_or_else(|e| panic!("failed to open '{}', {e}", &file.path().display()))
+        .unwrap_or_else(|e| panic!("failed to open '{}', {e}", file.path().display()))
         .read_to_end(&mut contents)
-        .unwrap_or_else(|e| panic!("failed to read '{}', {e}", &file.path().display()));
+        .unwrap_or_else(|e| panic!("failed to read '{}', {e}", file.path().display()));
     contents
 }

--- a/core/datatests/tests/suites/logical_line_parser.rs
+++ b/core/datatests/tests/suites/logical_line_parser.rs
@@ -108,7 +108,7 @@ fn assert_lines(
                 error_message.push_str(&format!(
                     "{} - line type: {:?}\n",
                     format_line(index, &line.line, tokens),
-                    &line.line.get_line_type()
+                    line.line.get_line_type()
                 ))
             });
 

--- a/core/src/rules/optimising_line_formatter/debug.rs
+++ b/core/src/rules/optimising_line_formatter/debug.rs
@@ -320,8 +320,7 @@ impl Debug for DebugFormattingSolution<'_, '_, '_> {
                 token_decision.requirement,
                 token_decision.decision,
                 token_decision.last_line_length,
-                &self
-                    .line_contexts
+                self.line_contexts
                     .get_specific_context_stack(line_index as u32)
                     .with_data(&recon_node)
                     .parents_support_break()

--- a/core/src/rules/optimising_line_formatter/requirements.rs
+++ b/core/src/rules/optimising_line_formatter/requirements.rs
@@ -75,7 +75,7 @@ impl InternalOptimisingLineFormatter<'_, '_> {
                 let parens_requirement = contexts_data
                     .get_last_context(context_matches!(CT::Brackets(_, _) | CT::SemicolonList))
                     .and_then(|(ctx, data)| {
-                        Some(data.is_broken).filter(|_| ctx.context_type() != CT::SemicolonList)
+                        (ctx.context_type() != CT::SemicolonList).then_some(data.is_broken)
                     })
                     .if_else_map(DR::MustBreak, DR::Indifferent);
 


### PR DESCRIPTION
Fixes these new lints:
- https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting
- https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#some_filter